### PR TITLE
feat(reading-history): 本地阅读历史与阅读进度追踪

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'screens/forum_list_screen.dart';
 import 'screens/thread_detail_screen.dart';
 import 'screens/compose_screen.dart';
 import 'screens/profile_screen.dart';
+import 'screens/reading_history_screen.dart';
 import 'screens/image_viewer_screen.dart';
 import 'services/talker.dart';
 import 'theme/app_theme.dart';
@@ -52,6 +53,10 @@ final _router = GoRouter(
     GoRoute(
       path: '/profile',
       builder: (context, state) => const ProfileScreen(),
+    ),
+    GoRoute(
+      path: '/reading-history',
+      builder: (context, state) => const ReadingHistoryScreen(),
     ),
     GoRoute(
       path: '/image-viewer',

--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -8,6 +8,12 @@ class S1Constants {
   static const int cookieRefreshIntervalMinutes = 30;
   static const Duration cacheExpiry = Duration(minutes: 5);
 
+  /// 帖子详情页每页帖数的兜底值。
+  /// 权威来源是 API 的 `ppp` 字段（viewthread，实际为 40）；仅在拿不到
+  /// API 值时（如帖子列表只有列表数据、无 `ppp`）使用此兜底值。
+  /// 注意：勿与 forumdisplay 的 `tpp`(=50，主题列表每页数) 混用。
+  static const int postsPerPageFallback = 40;
+
   /// 识别表情包路径的特征
   static bool isEmoticon(String url) {
     final lowerUrl = url.toLowerCase();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ void main() async {
   await Hive.openBox('cookies');
   await Hive.openBox('settings');
   await Hive.openBox('cache');
+  await Hive.openBox<Map>('reading_history');
 
   final container = ProviderContainer();
   final httpClient = container.read(httpClientProvider);

--- a/lib/models/reading_record.dart
+++ b/lib/models/reading_record.dart
@@ -1,0 +1,119 @@
+/// 阅读记录 / 阅读进度模型（纯 Dart，不依赖 Flutter）。
+///
+/// 存储于 Hive Box `reading_history`，value 为 [toJson] 的 Map。
+class ReadingRecord {
+  ReadingRecord({
+    required this.tid,
+    required this.subject,
+    required this.author,
+    required this.fid,
+    required this.lastReadPage,
+    required this.lastReadFloor,
+    required this.totalPages,
+    required this.totalReplies,
+    required this.perPage,
+    required this.lastReadAt,
+    required this.firstReadAt,
+    this.readCount = 1,
+  });
+
+  factory ReadingRecord.fromJson(Map<String, dynamic> json) {
+    return ReadingRecord(
+      tid: json['tid']?.toString() ?? '',
+      subject: json['subject']?.toString() ?? '',
+      author: json['author']?.toString() ?? '',
+      fid: json['fid']?.toString() ?? '',
+      lastReadPage: (json['lastReadPage'] as num?)?.toInt() ?? 1,
+      lastReadFloor: (json['lastReadFloor'] as num?)?.toInt() ?? 1,
+      totalPages: (json['totalPages'] as num?)?.toInt() ?? 1,
+      totalReplies: (json['totalReplies'] as num?)?.toInt() ?? 0,
+      perPage: (json['perPage'] as num?)?.toInt() ?? 0,
+      lastReadAt: (json['lastReadAt'] as num?)?.toInt() ?? 0,
+      firstReadAt: (json['firstReadAt'] as num?)?.toInt() ?? 0,
+      readCount: (json['readCount'] as num?)?.toInt() ?? 1,
+    );
+  }
+
+  final String tid;
+  final String subject;
+  final String author;
+  final String fid;
+
+  /// 最后阅读页码（1-based）
+  final int lastReadPage;
+
+  /// 最后阅读的绝对楼层（1-based，跨页累计）；仅用于展示，不参与判定。
+  final int lastReadFloor;
+
+  /// 帖子总页数（缓存）
+  final int totalPages;
+
+  /// 帖子总回复数（缓存）
+  final int totalReplies;
+
+  /// 每页帖数（来自 API `ppp`，缓存）
+  final int perPage;
+
+  /// 最后阅读时间（millisecondsSinceEpoch）
+  final int lastReadAt;
+
+  /// 首次阅读时间（millisecondsSinceEpoch）
+  final int firstReadAt;
+
+  /// 进入详情页次数（翻页不计）
+  final int readCount;
+
+  /// 阅读进度 0.0 ~ 1.0（页级，见计划 C2）。
+  double get progress =>
+      totalPages > 0 ? (lastReadPage / totalPages).clamp(0.0, 1.0) : 0.0;
+
+  /// 是否读完（页级判定，`totalPages` 已 clamp(1,…)）。
+  ///
+  /// 说明：数据流只知「已加载到第几页」，故按页级判定。0 回复帖
+  /// (`totalReplies == 0`) 亦满足 `totalPages == 1 && lastReadPage == 1 ⇒ 已读`。
+  bool get isFinished => lastReadPage >= totalPages;
+
+  Map<String, dynamic> toJson() => {
+        'tid': tid,
+        'subject': subject,
+        'author': author,
+        'fid': fid,
+        'lastReadPage': lastReadPage,
+        'lastReadFloor': lastReadFloor,
+        'totalPages': totalPages,
+        'totalReplies': totalReplies,
+        'perPage': perPage,
+        'lastReadAt': lastReadAt,
+        'firstReadAt': firstReadAt,
+        'readCount': readCount,
+      };
+
+  ReadingRecord copyWith({
+    String? subject,
+    String? author,
+    String? fid,
+    int? lastReadPage,
+    int? lastReadFloor,
+    int? totalPages,
+    int? totalReplies,
+    int? perPage,
+    int? lastReadAt,
+    int? firstReadAt,
+    int? readCount,
+  }) {
+    return ReadingRecord(
+      tid: tid,
+      subject: subject ?? this.subject,
+      author: author ?? this.author,
+      fid: fid ?? this.fid,
+      lastReadPage: lastReadPage ?? this.lastReadPage,
+      lastReadFloor: lastReadFloor ?? this.lastReadFloor,
+      totalPages: totalPages ?? this.totalPages,
+      totalReplies: totalReplies ?? this.totalReplies,
+      perPage: perPage ?? this.perPage,
+      lastReadAt: lastReadAt ?? this.lastReadAt,
+      firstReadAt: firstReadAt ?? this.firstReadAt,
+      readCount: readCount ?? this.readCount,
+    );
+  }
+}

--- a/lib/providers/post_provider.dart
+++ b/lib/providers/post_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../config/constants.dart';
 import '../models/post.dart';
 import '../services/api_service.dart';
 import '../services/http_client.dart';
@@ -11,6 +12,8 @@ class PostListState {
     this.totalPages = 1,
     this.threadSubject,
     this.threadFid,
+    this.perPage = S1Constants.postsPerPageFallback,
+    this.totalReplies = 0,
   });
   final List<Post> posts;
   final int currentPage;
@@ -18,12 +21,20 @@ class PostListState {
   final String? threadSubject;
   final String? threadFid;
 
+  /// 每页帖数（来自 API `ppp`，缺省用 fallback 40）
+  final int perPage;
+
+  /// 帖子总回复数（来自 API `thread.replies`）
+  final int totalReplies;
+
   PostListState copyWith({
     List<Post>? posts,
     int? currentPage,
     int? totalPages,
     String? threadSubject,
     String? threadFid,
+    int? perPage,
+    int? totalReplies,
   }) {
     return PostListState(
       posts: posts ?? this.posts,
@@ -31,6 +42,8 @@ class PostListState {
       totalPages: totalPages ?? this.totalPages,
       threadSubject: threadSubject ?? this.threadSubject,
       threadFid: threadFid ?? this.threadFid,
+      perPage: perPage ?? this.perPage,
+      totalReplies: totalReplies ?? this.totalReplies,
     );
   }
 }
@@ -64,46 +77,29 @@ class PostNotifier extends StateNotifier<AsyncValue<PostListState>> {
     try {
       final result = await _apiService.getThreadDetail(tid, page: page);
       final posts = ApiService.parsePostList(result);
-      final totalPages = _extractTotalPages(result);
-      final subject = _extractSubject(result);
-      final fid = _extractFid(result);
+
+      // 统一提取 variables / thread，避免重复遍历 JSON
+      final variables = result['Variables'] as Map<String, dynamic>? ?? {};
+      final thread = variables['thread'] as Map<String, dynamic>? ?? {};
+      // 每页帖数：API 字段 ppp（viewthread），拿不到时用 fallback 40（不是 30）
+      final perPage = int.tryParse(variables['ppp']?.toString() ?? '') ??
+          S1Constants.postsPerPageFallback;
+      final totalReplies = int.tryParse(thread['replies']?.toString() ?? '') ?? 0;
+      final totalPosts = totalReplies + 1; // 主楼 + 回复
+      final totalPages = (totalPosts / perPage).ceil().clamp(1, 9999);
+
       state = AsyncValue.data(PostListState(
         posts: posts,
         currentPage: page,
         totalPages: totalPages,
-        threadSubject: subject,
-        threadFid: fid,
+        threadSubject: thread['subject']?.toString(),
+        threadFid: thread['fid']?.toString(),
+        perPage: perPage,
+        totalReplies: totalReplies,
       ),);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
     }
-  }
-
-  int _extractTotalPages(Map<String, dynamic> json) {
-    final variables = json['Variables'] as Map<String, dynamic>?;
-    if (variables == null) return 1;
-    // Discuz! viewthread 返回 thread 数组中的 replies + 1 为总帖数
-    final thread = variables['thread'] as Map<String, dynamic>?;
-    if (thread == null) return 1;
-    final replies = int.tryParse(thread['replies']?.toString() ?? '') ?? 0;
-    // 每页帖数，API 字段名为 ppp (posts per page)
-    final perPage = int.tryParse(variables['ppp']?.toString() ?? '') ?? 30;
-    final totalPosts = replies + 1; // 主楼 + 回复
-    return (totalPosts / perPage).ceil().clamp(1, 9999);
-  }
-
-  String? _extractSubject(Map<String, dynamic> json) {
-    final variables = json['Variables'] as Map<String, dynamic>?;
-    if (variables == null) return null;
-    final thread = variables['thread'] as Map<String, dynamic>?;
-    return thread?['subject']?.toString();
-  }
-
-  String? _extractFid(Map<String, dynamic> json) {
-    final variables = json['Variables'] as Map<String, dynamic>?;
-    if (variables == null) return null;
-    final thread = variables['thread'] as Map<String, dynamic>?;
-    return thread?['fid']?.toString();
   }
 
   Future<void> goToPage(int page) async {

--- a/lib/providers/reading_history_provider.dart
+++ b/lib/providers/reading_history_provider.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import '../models/reading_record.dart';
+import '../services/reading_history_service.dart';
+import 'auth_provider.dart';
+
+/// 已打开的 Hive Box（在 `main.dart` 中 openBox）。
+final readingBoxProvider = Provider<Box<Map>>((ref) {
+  return Hive.box<Map>('reading_history');
+});
+
+/// 依赖登录态获取当前 uid，实现按用户隔离。
+final readingHistoryServiceProvider = Provider<ReadingHistoryService>((ref) {
+  final box = ref.watch(readingBoxProvider);
+  // User.uid 缺省为空串 ''（非 null），Web 端登录后会短暂为空，必须把空串
+  // 也归到 guest，否则 key 前缀会变成 "_{tid}" 污染数据。
+  final rawUid = ref.watch(authStateProvider).user?.uid;
+  final uid = (rawUid == null || rawUid.isEmpty) ? 'guest' : rawUid;
+  return ReadingHistoryService(box, uid);
+});
+
+/// 单条帖子的阅读记录（供 ThreadCard / ThreadDetailScreen 使用）。
+/// 写入进度后需 `ref.invalidate(readingRecordProvider(tid))` 才会刷新。
+final readingRecordProvider = Provider.family<ReadingRecord?, String>((ref, tid) {
+  return ref.watch(readingHistoryServiceProvider).getRecord(tid);
+});
+
+/// 阅读历史列表（供历史页面使用）。
+final readingHistoryProvider =
+    StateNotifierProvider<ReadingHistoryNotifier, List<ReadingRecord>>((ref) {
+  return ReadingHistoryNotifier(ref.watch(readingHistoryServiceProvider));
+});
+
+class ReadingHistoryNotifier extends StateNotifier<List<ReadingRecord>> {
+  ReadingHistoryNotifier(this._service) : super(_service.getAllRecords());
+
+  final ReadingHistoryService _service;
+
+  void refresh() => state = _service.getAllRecords();
+
+  void delete(String tid) {
+    _service.deleteRecord(tid);
+    state = _service.getAllRecords();
+  }
+
+  Future<void> clearAll() async {
+    await _service.clearAll();
+    state = [];
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -6,6 +6,7 @@ import '../config/api_config.dart';
 import '../theme/app_theme.dart';
 import '../utils/format_utils.dart';
 import '../providers/auth_provider.dart';
+import '../providers/reading_history_provider.dart';
 import '../providers/settings_provider.dart';
 import '../providers/talker_provider.dart';
 import '../services/talker.dart' as t;
@@ -74,6 +75,8 @@ class ProfileBody extends ConsumerWidget {
           _InfoCard(user: user),
         ],
         const SizedBox(height: 20),
+        const _ReadingHistoryTile(),
+        const SizedBox(height: 16),
         _ThemeSettingsCard(
           themeMode: settings.themeMode,
           themeColor: settings.themeColor,
@@ -683,6 +686,44 @@ class _VersionTileState extends ConsumerState<_VersionTile> {
       ),
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _ReadingHistoryTile extends ConsumerWidget {
+  const _ReadingHistoryTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(readingHistoryProvider).length;
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Card(
+      elevation: 0,
+      shape: S1Shape.cardShape,
+      color: colorScheme.surfaceContainerHighest
+          .withValues(alpha: S1Alpha.cardOverlay),
+      child: ListTile(
+        leading: Icon(Icons.history, color: colorScheme.primary),
+        title: const Text('阅读历史'),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (count > 0)
+              Text(
+                '$count',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            const SizedBox(width: 4),
+            Icon(Icons.chevron_right, color: colorScheme.onSurfaceVariant),
+          ],
+        ),
+        shape: const RoundedRectangleBorder(borderRadius: S1Shape.large),
+        onTap: () => context.push('/reading-history'),
+      ),
     );
   }
 }

--- a/lib/screens/reading_history_screen.dart
+++ b/lib/screens/reading_history_screen.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../models/reading_record.dart';
+import '../providers/forum_list_provider.dart';
+import '../providers/reading_history_provider.dart';
+import '../theme/app_theme.dart';
+import '../utils/format_utils.dart';
+
+class ReadingHistoryScreen extends ConsumerWidget {
+  const ReadingHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final records = ref.watch(readingHistoryProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        title: const Text('阅读历史'),
+        actions: [
+          if (records.isNotEmpty)
+            IconButton(
+              tooltip: '清空',
+              icon: const Icon(Icons.delete_sweep_outlined),
+              onPressed: () => _confirmClearAll(context, ref),
+            ),
+        ],
+      ),
+      body: records.isEmpty
+          ? const _EmptyState()
+          : ListView.builder(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              itemCount: records.length,
+              itemBuilder: (context, index) =>
+                  _HistoryTile(record: records[index]),
+            ),
+    );
+  }
+
+  Future<void> _confirmClearAll(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('清空阅读历史'),
+        content: const Text('将删除全部阅读记录，此操作不可恢复。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('清空'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await ref.read(readingHistoryProvider.notifier).clearAll();
+    }
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.history, size: 56, color: scheme.onSurfaceVariant),
+          const SizedBox(height: 16),
+          Text(
+            '暂无阅读记录',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryTile extends ConsumerWidget {
+  const _HistoryTile({required this.record});
+  final ReadingRecord record;
+
+  String? _forumName(WidgetRef ref) {
+    final categories = ref.watch(forumListProvider).valueOrNull;
+    if (categories == null || record.fid.isEmpty) return null;
+    for (final category in categories) {
+      if (category.fid == record.fid) return category.name;
+      for (final sub in category.subforums) {
+        if (sub.fid == record.fid) return sub.name;
+      }
+    }
+    return null;
+  }
+
+  void _open(BuildContext context) {
+    if (!record.isFinished && record.lastReadPage > 1) {
+      context.push('/thread/${record.tid}?page=${record.lastReadPage}');
+    } else {
+      context.push('/thread/${record.tid}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final isFinished = record.isFinished;
+    final accent = isFinished ? scheme.onSurfaceVariant : scheme.primary;
+    final forumName = _forumName(ref);
+
+    final metaParts = <String>[
+      if (record.author.isNotEmpty) record.author,
+      if (forumName != null && forumName.isNotEmpty) forumName,
+      formatTimeAgo(record.lastReadAt ~/ 1000),
+      if (record.readCount > 1) '读过 ${record.readCount} 次',
+    ];
+
+    return Dismissible(
+      key: ValueKey('reading_history_${record.tid}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        color: scheme.errorContainer,
+        child: Icon(Icons.delete_outline, color: scheme.onErrorContainer),
+      ),
+      onDismissed: (_) =>
+          ref.read(readingHistoryProvider.notifier).delete(record.tid),
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        elevation: 0,
+        color: scheme.surfaceContainerLow,
+        shape: S1Shape.cardShape,
+        child: InkWell(
+          onTap: () => _open(context),
+          borderRadius: const BorderRadius.all(Radius.circular(12)),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  record.subject.isEmpty ? '(无标题)' : record.subject,
+                  style: textTheme.titleSmall?.copyWith(height: 1.4),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  metaParts.join(' · '),
+                  style: textTheme.labelSmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      isFinished ? Icons.check_circle_outline : Icons.schedule,
+                      size: 13,
+                      color: accent,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(2)),
+                        child: LinearProgressIndicator(
+                          value: record.progress,
+                          minHeight: 4,
+                          backgroundColor: scheme.surfaceContainerHighest,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            isFinished
+                                ? scheme.onSurfaceVariant.withValues(alpha: 0.3)
+                                : scheme.primary,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      isFinished
+                          ? '已读'
+                          : 'P${record.lastReadPage}/${record.totalPages}',
+                      style: textTheme.labelSmall?.copyWith(
+                        color: accent,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../config/api_config.dart';
 import '../providers/post_provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/reading_history_provider.dart';
 import '../services/api_service.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/post_item.dart';
@@ -21,6 +22,8 @@ class ThreadDetailScreen extends ConsumerStatefulWidget {
 class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   final _scrollController = ScrollController();
   bool _showScrollToTop = false;
+  bool _hasRecordedInitialVisit = false;
+  bool _hasCheckedResume = false;
 
   @override
   void initState() {
@@ -31,6 +34,53 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         ref.read(postProvider(widget.tid).notifier).goToPage(widget.initialPage!);
       });
     }
+  }
+
+  /// 记录阅读进度：写库 + 失效单条 provider（C4）。
+  /// readCount 只在本次进入详情页首帧 +1（isNewVisit 由 _hasRecordedInitialVisit 守卫）。
+  void _recordProgress(PostListState state) {
+    ref.read(readingHistoryServiceProvider).updateProgress(
+          tid: widget.tid,
+          page: state.currentPage,
+          floorInPage: state.posts.length,
+          subject: state.threadSubject ?? '',
+          author: state.posts.isNotEmpty ? state.posts.first.author : '',
+          fid: state.threadFid ?? '',
+          totalPages: state.totalPages,
+          totalReplies: state.totalReplies,
+          perPage: state.perPage,
+          isNewVisit: !_hasRecordedInitialVisit,
+        );
+    _hasRecordedInitialVisit = true;
+    ref.invalidate(readingRecordProvider(widget.tid));
+  }
+
+  /// 无指定初始页时，若存在未读完的历史记录，提示续读。
+  void _checkResumeReading(PostListState state) {
+    if (_hasCheckedResume) return;
+    _hasCheckedResume = true;
+    final record = ref.read(readingRecordProvider(widget.tid));
+    if (record == null ||
+        record.isFinished ||
+        record.lastReadPage <= 1 ||
+        record.lastReadPage == state.currentPage) {
+      return;
+    }
+    final targetPage = record.lastReadPage;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('上次阅读到第 $targetPage 页'),
+          action: SnackBarAction(
+            label: '续读',
+            onPressed: () =>
+                ref.read(postProvider(widget.tid).notifier).goToPage(targetPage),
+          ),
+          duration: const Duration(seconds: 5),
+        ),
+      );
+    });
   }
 
   @override
@@ -86,6 +136,16 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<PostListState>>(postProvider(widget.tid),
+        (previous, next) {
+      next.whenData((state) {
+        _recordProgress(state);
+        if (widget.initialPage == null) {
+          _checkResumeReading(state);
+        }
+      });
+    });
+
     final postsAsync = ref.watch(postProvider(widget.tid));
     final isLoggedIn = ref.watch(authStateProvider).isLoggedIn;
 
@@ -170,7 +230,8 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
                         itemCount: state.posts.length,
                         itemBuilder: (context, index) {
                           final post = state.posts[index];
-                          final floorOffset = (state.currentPage - 1) * 30;
+                          final floorOffset =
+                              (state.currentPage - 1) * state.perPage;
                           return PostItem(
                             post: post,
                             displayFloor: floorOffset + index + 1,

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -36,7 +36,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     }
   }
 
-  /// 记录阅读进度：写库 + 失效单条 provider（C4）。
+  /// 记录阅读进度：写库 + 刷新历史列表（使列表卡片/历史页/资料计数实时更新）。
   /// readCount 只在本次进入详情页首帧 +1（isNewVisit 由 _hasRecordedInitialVisit 守卫）。
   void _recordProgress(PostListState state) {
     ref.read(readingHistoryServiceProvider).updateProgress(
@@ -53,9 +53,12 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         );
     _hasRecordedInitialVisit = true;
     ref.invalidate(readingRecordProvider(widget.tid));
+    // 刷新列表 StateNotifier：ThreadCard 进度条 / 历史页 / 资料计数据此实时更新。
+    ref.read(readingHistoryProvider.notifier).refresh();
   }
 
   /// 无指定初始页时，若存在未读完的历史记录，提示续读。
+  /// 必须在 [_recordProgress] 写库**之前**读取，否则读到的就是本次刚写入的当前页。
   void _checkResumeReading(PostListState state) {
     if (_hasCheckedResume) return;
     _hasCheckedResume = true;
@@ -139,10 +142,11 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     ref.listen<AsyncValue<PostListState>>(postProvider(widget.tid),
         (previous, next) {
       next.whenData((state) {
-        _recordProgress(state);
+        // 先按「上一次」记录判断是否提示续读，再写入本次进度。
         if (widget.initialPage == null) {
           _checkResumeReading(state);
         }
+        _recordProgress(state);
       });
     });
 

--- a/lib/services/reading_history_service.dart
+++ b/lib/services/reading_history_service.dart
@@ -1,0 +1,108 @@
+import 'package:hive/hive.dart';
+import '../models/reading_record.dart';
+
+/// 阅读历史服务层：封装 Hive CRUD 与按用户隔离的 LRU 淘汰。
+///
+/// - 接收已在 `main.dart` 打开的 `Box<Map>`，不自行 openBox（遵守架构边界）。
+/// - key 格式 `{uid}_{tid}`，实现多账号隔离；uid 为空时调用方应传 `guest`。
+class ReadingHistoryService {
+  ReadingHistoryService(this._box, this._uid);
+
+  final Box<Map> _box;
+  final String _uid;
+
+  static const int maxRecords = 500;
+
+  String _key(String tid) => '${_uid}_$tid';
+
+  bool _belongsToUser(dynamic key) =>
+      key is String && key.startsWith('${_uid}_');
+
+  /// 更新（或创建）阅读进度。
+  ///
+  /// [isNewVisit] 为本次进入详情页的首帧标记：为 true 时 `readCount + 1`，
+  /// 翻页 / 刷新时应传 false，避免重复计数。
+  void updateProgress({
+    required String tid,
+    required int page,
+    required int floorInPage,
+    required String subject,
+    required String author,
+    required String fid,
+    required int totalPages,
+    required int totalReplies,
+    required int perPage,
+    bool isNewVisit = false,
+  }) {
+    if (tid.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final absoluteFloor = (page - 1) * perPage + floorInPage;
+    final key = _key(tid);
+    final existing = _box.get(key);
+    final firstReadAt =
+        existing != null ? ((existing['firstReadAt'] as num?)?.toInt() ?? now) : now;
+    final prevCount =
+        existing != null ? ((existing['readCount'] as num?)?.toInt() ?? 0) : 0;
+
+    final record = ReadingRecord(
+      tid: tid,
+      subject: subject,
+      author: author,
+      fid: fid,
+      lastReadPage: page,
+      lastReadFloor: absoluteFloor,
+      totalPages: totalPages,
+      totalReplies: totalReplies,
+      perPage: perPage,
+      lastReadAt: now,
+      firstReadAt: firstReadAt,
+      readCount: isNewVisit ? prevCount + 1 : (prevCount == 0 ? 1 : prevCount),
+    );
+    _box.put(key, record.toJson());
+    _evictIfNeeded();
+  }
+
+  ReadingRecord? getRecord(String tid) {
+    final data = _box.get(_key(tid));
+    if (data == null) return null;
+    return ReadingRecord.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  /// 当前用户的全部记录，按 `lastReadAt` 倒序。
+  List<ReadingRecord> getAllRecords() {
+    final records = <ReadingRecord>[];
+    for (final key in _box.keys) {
+      if (!_belongsToUser(key)) continue;
+      final value = _box.get(key);
+      if (value == null) continue;
+      records.add(ReadingRecord.fromJson(Map<String, dynamic>.from(value)));
+    }
+    records.sort((a, b) => b.lastReadAt.compareTo(a.lastReadAt));
+    return records;
+  }
+
+  int get count => _box.keys.where(_belongsToUser).length;
+
+  void deleteRecord(String tid) {
+    _box.delete(_key(tid));
+  }
+
+  /// 仅清空当前用户的记录。
+  Future<void> clearAll() async {
+    final keys = _box.keys.where(_belongsToUser).toList();
+    await _box.deleteAll(keys);
+  }
+
+  /// LRU 淘汰：仅按当前用户计数，超限删除最旧（`lastReadAt` 最小）。
+  void _evictIfNeeded() {
+    final keys = _box.keys.where(_belongsToUser).toList();
+    if (keys.length <= maxRecords) return;
+    keys.sort((a, b) {
+      final at = (_box.get(a)?['lastReadAt'] as num?)?.toInt() ?? 0;
+      final bt = (_box.get(b)?['lastReadAt'] as num?)?.toInt() ?? 0;
+      return at.compareTo(bt);
+    });
+    final removeCount = keys.length - maxRecords;
+    _box.deleteAll(keys.take(removeCount));
+  }
+}

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -2,10 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../config/constants.dart';
+import '../models/reading_record.dart';
 import '../models/thread.dart';
 import '../providers/reading_history_provider.dart';
 import '../theme/app_theme.dart';
 import '../utils/format_utils.dart';
+
+/// 从当前用户的阅读历史列表中查出指定 tid 的记录（无则 null）。
+ReadingRecord? _recordFor(List<ReadingRecord> list, String tid) {
+  for (final r in list) {
+    if (r.tid == tid) return r;
+  }
+  return null;
+}
 
 class ThreadCard extends ConsumerWidget {
 
@@ -20,7 +29,7 @@ class ThreadCard extends ConsumerWidget {
 
   /// 点击：有未读完记录则续读到上次页码，否则从第一页打开。
   void _handleTap(BuildContext context, WidgetRef ref) {
-    final record = ref.read(readingRecordProvider(thread.tid));
+    final record = _recordFor(ref.read(readingHistoryProvider), thread.tid);
     if (record != null && !record.isFinished && record.lastReadPage > 1) {
       context.push('/thread/${thread.tid}?page=${record.lastReadPage}');
     } else {
@@ -115,7 +124,10 @@ class _ReadingProgressBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final record = ref.watch(readingRecordProvider(tid));
+    // 从历史列表按 tid 选取，随 readingHistoryProvider 刷新而实时更新。
+    final record = ref.watch(
+      readingHistoryProvider.select((list) => _recordFor(list, tid)),
+    );
     if (record == null || record.progress <= 0) {
       return const SizedBox.shrink();
     }

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -1,17 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../config/constants.dart';
 import '../models/thread.dart';
+import '../providers/reading_history_provider.dart';
 import '../theme/app_theme.dart';
 import '../utils/format_utils.dart';
 
-class ThreadCard extends StatelessWidget {
+class ThreadCard extends ConsumerWidget {
 
   const ThreadCard({super.key, required this.thread});
   final Thread thread;
 
-  int _calcTotalPages(int replies, {int perPage = 40}) {
+  int _calcTotalPages(int replies,
+      {int perPage = S1Constants.postsPerPageFallback,}) {
     final totalPosts = replies + 1;
     return (totalPosts / perPage).ceil().clamp(1, 9999);
+  }
+
+  /// 点击：有未读完记录则续读到上次页码，否则从第一页打开。
+  void _handleTap(BuildContext context, WidgetRef ref) {
+    final record = ref.read(readingRecordProvider(thread.tid));
+    if (record != null && !record.isFinished && record.lastReadPage > 1) {
+      context.push('/thread/${thread.tid}?page=${record.lastReadPage}');
+    } else {
+      context.push('/thread/${thread.tid}');
+    }
   }
 
   void _showPageSheet(BuildContext context) {
@@ -35,7 +49,7 @@ class ThreadCard extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final scheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     final hasTag = thread.typeName != null && thread.typeName!.isNotEmpty;
@@ -54,7 +68,7 @@ class ThreadCard extends StatelessWidget {
           : scheme.surfaceContainerLow,
       shape: S1Shape.cardShape,
       child: InkWell(
-        onTap: () => context.push('/thread/${thread.tid}'),
+        onTap: () => _handleTap(context, ref),
         borderRadius: const BorderRadius.all(Radius.circular(12)),
         child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -82,9 +96,69 @@ class ThreadCard extends StatelessWidget {
                     ? () => _showPageSheet(context)
                     : null,
               ),
+              _ReadingProgressBar(tid: thread.tid),
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+//  阅读进度指示器：无记录时不占位
+// ═══════════════════════════════════════════════════════════
+
+class _ReadingProgressBar extends ConsumerWidget {
+  const _ReadingProgressBar({required this.tid});
+  final String tid;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final record = ref.watch(readingRecordProvider(tid));
+    if (record == null || record.progress <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final isFinished = record.isFinished;
+    final accent = isFinished ? scheme.onSurfaceVariant : scheme.primary;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        children: [
+          Icon(
+            isFinished ? Icons.check_circle_outline : Icons.schedule,
+            size: 12,
+            color: accent,
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(2)),
+              child: LinearProgressIndicator(
+                value: record.progress,
+                minHeight: 3,
+                backgroundColor: scheme.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  isFinished
+                      ? scheme.onSurfaceVariant.withValues(alpha: 0.3)
+                      : scheme.primary,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            isFinished ? '已读' : 'P${record.lastReadPage}',
+            style: textTheme.labelSmall?.copyWith(
+              color: accent,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -308,7 +382,7 @@ class _ThreadPageSheet extends StatelessWidget {
   final String subject;
   final int totalPages;
 
-  static const int _perPage = 40;
+  static const int _perPage = S1Constants.postsPerPageFallback;
 
   @override
   Widget build(BuildContext context) {

--- a/test/models/reading_record_test.dart
+++ b/test/models/reading_record_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/reading_record.dart';
+
+ReadingRecord _make({
+  int lastReadPage = 1,
+  int totalPages = 1,
+  int totalReplies = 0,
+  int readCount = 1,
+}) {
+  return ReadingRecord(
+    tid: '123',
+    subject: '标题',
+    author: 'author',
+    fid: '4',
+    lastReadPage: lastReadPage,
+    lastReadFloor: 1,
+    totalPages: totalPages,
+    totalReplies: totalReplies,
+    perPage: 40,
+    lastReadAt: 1700000000000,
+    firstReadAt: 1699999999000,
+    readCount: readCount,
+  );
+}
+
+void main() {
+  group('ReadingRecord.progress', () {
+    test('半程进度按页级计算', () {
+      expect(_make(lastReadPage: 2, totalPages: 4).progress, 0.5);
+    });
+
+    test('进度被 clamp 到 [0,1]', () {
+      expect(_make(lastReadPage: 9, totalPages: 4).progress, 1.0);
+    });
+
+    test('totalPages 为 0 时进度为 0', () {
+      expect(_make(totalPages: 0).progress, 0.0);
+    });
+  });
+
+  group('ReadingRecord.isFinished（页级，修正 0 回复 bug）', () {
+    test('读到最后一页视为已读', () {
+      expect(_make(lastReadPage: 4, totalPages: 4).isFinished, isTrue);
+    });
+
+    test('未到最后一页视为未读完', () {
+      expect(_make(lastReadPage: 2, totalPages: 4).isFinished, isFalse);
+    });
+
+    test('0 回复单页帖首次进入即已读（v1.0 楼层级公式的 bug 已修）', () {
+      final r = _make(lastReadPage: 1, totalPages: 1, totalReplies: 0);
+      expect(r.isFinished, isTrue);
+    });
+  });
+
+  group('ReadingRecord 序列化', () {
+    test('toJson/fromJson 往返保持字段', () {
+      final r = _make(lastReadPage: 3, totalPages: 5, readCount: 7);
+      final restored = ReadingRecord.fromJson(r.toJson());
+      expect(restored.tid, r.tid);
+      expect(restored.lastReadPage, 3);
+      expect(restored.totalPages, 5);
+      expect(restored.perPage, 40);
+      expect(restored.readCount, 7);
+      expect(restored.firstReadAt, r.firstReadAt);
+    });
+
+    test('fromJson 容忍缺失字段', () {
+      final r = ReadingRecord.fromJson({'tid': '9'});
+      expect(r.tid, '9');
+      expect(r.lastReadPage, 1);
+      expect(r.totalPages, 1);
+      expect(r.readCount, 1);
+    });
+  });
+}

--- a/test/screens/profile_screen_test.dart
+++ b/test/screens/profile_screen_test.dart
@@ -13,6 +13,7 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     Hive.init(Directory.systemTemp.path);
     await Hive.openBox('settings');
+    await Hive.openBox<Map>('reading_history');
   });
 
   tearDownAll(() async {

--- a/test/services/reading_history_service_test.dart
+++ b/test/services/reading_history_service_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:s1_app/services/reading_history_service.dart';
+
+void main() {
+  late Box<Map> box;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    Hive.init(Directory.systemTemp.createTempSync('s1_reading_hist').path);
+  });
+
+  setUp(() async {
+    box = await Hive.openBox<Map>('reading_history_test_${DateTime.now().microsecondsSinceEpoch}');
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+  });
+
+  ReadingHistoryService service(String uid) => ReadingHistoryService(box, uid);
+
+  void record(
+    ReadingHistoryService s,
+    String tid, {
+    int page = 1,
+    int totalPages = 3,
+    bool isNewVisit = true,
+  }) {
+    s.updateProgress(
+      tid: tid,
+      page: page,
+      floorInPage: 5,
+      subject: '主题$tid',
+      author: 'a',
+      fid: '4',
+      totalPages: totalPages,
+      totalReplies: 100,
+      perPage: 40,
+      isNewVisit: isNewVisit,
+    );
+  }
+
+  test('创建记录并计算绝对楼层', () {
+    final s = service('u1');
+    record(s, '100', page: 2);
+    final r = s.getRecord('100');
+    expect(r, isNotNull);
+    expect(r!.lastReadPage, 2);
+    // (2-1)*40 + 5
+    expect(r.lastReadFloor, 45);
+    expect(r.readCount, 1);
+  });
+
+  test('readCount 仅在 isNewVisit 时递增（翻页不计）', () {
+    final s = service('u1');
+    record(s, '100', page: 1, isNewVisit: true); // 首次进入 -> 1
+    record(s, '100', page: 2, isNewVisit: false); // 翻页 -> 不加
+    expect(s.getRecord('100')!.readCount, 1);
+    record(s, '100', page: 1, isNewVisit: true); // 再次进入 -> 2
+    expect(s.getRecord('100')!.readCount, 2);
+  });
+
+  test('firstReadAt 在更新时保持不变', () {
+    final s = service('u1');
+    record(s, '100');
+    final first = s.getRecord('100')!.firstReadAt;
+    record(s, '100', page: 2, isNewVisit: false);
+    expect(s.getRecord('100')!.firstReadAt, first);
+  });
+
+  test('getAllRecords 按 lastReadAt 倒序', () async {
+    final s = service('u1');
+    record(s, 'A');
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    record(s, 'B');
+    final all = s.getAllRecords();
+    expect(all.map((e) => e.tid).toList(), ['B', 'A']);
+  });
+
+  test('多账号隔离：仅返回/清空当前 uid 的记录', () async {
+    final u1 = service('u1');
+    final guest = service('guest');
+    record(u1, '100');
+    record(guest, '200');
+
+    expect(u1.getAllRecords().map((e) => e.tid), ['100']);
+    expect(guest.getAllRecords().map((e) => e.tid), ['200']);
+    expect(u1.count, 1);
+
+    await u1.clearAll();
+    expect(u1.getAllRecords(), isEmpty);
+    // guest 记录不受影响
+    expect(guest.getRecord('200'), isNotNull);
+  });
+
+  test('deleteRecord 只删当前用户对应 tid', () {
+    final s = service('u1');
+    record(s, '100');
+    record(s, '101');
+    s.deleteRecord('100');
+    expect(s.getRecord('100'), isNull);
+    expect(s.getRecord('101'), isNotNull);
+  });
+
+  test('超过上限按 lastReadAt 淘汰最旧（按 uid 计数）', () async {
+    final s = service('u1');
+    // 造 maxRecords + 2 条，第一条最旧
+    for (var i = 0; i < ReadingHistoryService.maxRecords + 2; i++) {
+      record(s, 't$i');
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+    expect(s.count, ReadingHistoryService.maxRecords);
+    // 最旧的两条应被淘汰
+    expect(s.getRecord('t0'), isNull);
+    expect(s.getRecord('t1'), isNull);
+    expect(s.getRecord('t2'), isNotNull);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

按 `docs/reading-history-plan.md`（v1.1 修正版）实现本地阅读历史 + 阅读进度追踪：进入帖子自动记录，帖子卡片显示进度标识，可续读，个人资料页提供历史入口，历史页支持删除/清空。纯本地（Hive），不引入新依赖，遵守 Screen → Provider → Service → Hive 架构与 M3 规范。

## 改动

**新增**
- `lib/models/reading_record.dart`：纯 Dart 模型；`progress`/`isFinished` 均为**页级**语义（修正 v1.0 在 0 回复帖上恒 false 的 bug）。
- `lib/services/reading_history_service.dart`：接收已打开的 `Box<Map>` + uid，key `{uid}_{tid}` 实现多账号隔离；`updateProgress`/`getRecord`/`getAllRecords`/`delete`/`clearAll` 与**按 uid 计数**的 LRU 淘汰（上限 500）。
- `lib/providers/reading_history_provider.dart`：`StateNotifier` 风格；uid 为空串归一到 `guest`（C3）。
- `lib/screens/reading_history_screen.dart`：历史列表（版块名经 `forumListProvider` 解析）、侧滑删除、清空确认、空状态、点击续读。

**修改**
- `lib/config/constants.dart`：新增 `postsPerPageFallback = 40`（**C1**：每页帖数权威值是 `ppp=40`，消灭散落的 30/40 字面量）。
- `lib/providers/post_provider.dart`：`PostListState` 新增 `perPage`/`totalReplies`；统一提取 `variables`，`ppp` fallback 由 30 改为 **40**。
- `lib/screens/thread_detail_screen.dart`：`ref.listen` 记录进度并刷新历史列表；楼层偏移改用 `state.perPage`（修正硬编码 `*30`，**P2**）；**先判断续读、再写入进度**（修复顺序 bug，否则续读永不触发）。
- `lib/widgets/thread_card.dart`：改 `ConsumerWidget`；进度条从 `readingHistoryProvider` 取值以实时刷新；未读完记录点击直接续读；per-page 用共享常量 40。
- `lib/screens/profile_screen.dart`、`lib/app.dart`、`lib/main.dart`：入口卡片（含记录数）、`/reading-history` 路由、打开 `reading_history` box。
- `test/screens/profile_screen_test.dart`：`setUpAll` 补开 `reading_history` box（页面新增依赖）。

## 测试

- ✅ `flutter analyze` — No issues found
- ✅ `flutter test` — 95/95（新增 `reading_record`、`reading_history_service` 单测 15 个，覆盖进度/已读语义、readCount 计次、多账号隔离、LRU 淘汰）
- ✅ 手动端到端（复用既有登录会话，未重复登录）：卡片进度条 `P2`、点击续读直达第 2 页、历史页 `P2/3`

### 演示

<a href="https://cursor.com/agents/bc-77694499-b735-4e6a-8f28-96ca145ce198/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freading_history_feature_demo.mp4"><img src="https://cursor.com/artifacts/c/art-c5697085-5c66-4985-80d2-ea03b31597c8" alt="reading_history_feature_demo.mp4" /></a>

![卡片进度指示 P2](https://cursor.com/artifacts/c/art-0dc1af29-3077-4b33-8702-47da2fc72e6f)
![续读直达第2页](https://cursor.com/artifacts/c/art-0f251d92-8983-443b-bded-f1477e23dd10)
![阅读历史页 P2/3](https://cursor.com/artifacts/c/art-d69df26b-8178-46ee-a80b-4661220e0952)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77694499-b735-4e6a-8f28-96ca145ce198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77694499-b735-4e6a-8f28-96ca145ce198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

