### PR TITLE
fix(m3): 恢复 AppBar 默认滚动 Surface Tint 并收敛圆角 token

### DIFF
--- a/lib/screens/compose_screen.dart
+++ b/lib/screens/compose_screen.dart
@@ -82,7 +82,6 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: Text(widget.tid != null ? '回复' : '发帖'),
         actions: [
           FilledButton(

--- a/lib/screens/forum_list_screen.dart
+++ b/lib/screens/forum_list_screen.dart
@@ -69,7 +69,6 @@ class _ForumListScreenState extends ConsumerState<ForumListScreen> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: Text(forum.isNotEmpty ? forum : '版块 #${widget.fid}'),
         actions: [
           AppBarMoreMenu(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -29,7 +29,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: Text(_currentTab == 3 ? '个人资料' : 'Stage1st'),
         actions: _currentTab == 3
             ? [

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -64,7 +64,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: const Text('登录 Stage1st'),
       ),
       body: Center(

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -156,7 +156,7 @@ class _HeaderCard extends StatelessWidget {
                   ),
                   decoration: BoxDecoration(
                     color: colorScheme.primaryContainer,
-                    borderRadius: const BorderRadius.all(Radius.circular(9999)),
+                    borderRadius: S1Shape.full,
                   ),
                   child: Text(
                     groupTitle!,

--- a/lib/screens/reading_history_screen.dart
+++ b/lib/screens/reading_history_screen.dart
@@ -17,7 +17,6 @@ class ReadingHistoryScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: const Text('阅读历史'),
         actions: [
           if (records.isNotEmpty)
@@ -144,7 +143,7 @@ class _HistoryTile extends ConsumerWidget {
         shape: S1Shape.cardShape,
         child: InkWell(
           onTap: () => _open(context),
-          borderRadius: const BorderRadius.all(Radius.circular(12)),
+          borderRadius: S1Shape.medium,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
             child: Column(

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -156,7 +156,6 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        scrolledUnderElevation: 0,
         title: postsAsync.whenOrNull(
               data: (s) => s.threadSubject != null
                   ? GestureDetector(

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -8,6 +8,9 @@ abstract class S1Shape {
   static const large = BorderRadius.all(Radius.circular(16));
   static const extraLarge = BorderRadius.all(Radius.circular(28));
 
+  /// 全圆角（胶囊 / pill），用于标签、徽标等 M3 "full" 形状。
+  static const full = BorderRadius.all(Radius.circular(999));
+
   static const cardShape = RoundedRectangleBorder(borderRadius: medium);
   static const dialogShape = RoundedRectangleBorder(borderRadius: extraLarge);
   static const bottomSheetShape = RoundedRectangleBorder(

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -78,7 +78,7 @@ class ThreadCard extends ConsumerWidget {
       shape: S1Shape.cardShape,
       child: InkWell(
         onTap: () => _handleTap(context, ref),
-        borderRadius: const BorderRadius.all(Radius.circular(12)),
+        borderRadius: S1Shape.medium,
         child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           child: Column(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

M3 审核发现：6 个页面的 AppBar 设了 `scrolledUnderElevation: 0`，**禁用了 M3 在内容滚动到 AppBar 下方时的 surface tint 层级信号**——这与项目宪法自身「层级靠 Surface Tint」的原则相矛盾。本 PR 恢复 M3 默认行为，并顺带把散落的圆角字面量收敛到 `S1Shape` token。

## 变更

**恢复 M3 默认（移除 `scrolledUnderElevation: 0`，保留静止态 `elevation: 0`）**
- `lib/screens/home_screen.dart`
- `lib/screens/thread_detail_screen.dart`
- `lib/screens/login_screen.dart`
- `lib/screens/forum_list_screen.dart`
- `lib/screens/compose_screen.dart`
- `lib/screens/reading_history_screen.dart`

（`profile_screen.dart` 的 AppBar 本就是 M3 默认，未改动。）

**圆角 token 收敛**
- `lib/theme/app_theme.dart`：新增 `S1Shape.full`（全圆角/胶囊，M3 "full" 形状）
- `lib/screens/profile_screen.dart`：用户组徽标 `Radius.circular(9999)` → `S1Shape.full`
- `lib/widgets/thread_card.dart`、`lib/screens/reading_history_screen.dart`：`Radius.circular(12)` → `S1Shape.medium`（消除我在阅读历史 PR 引入的 token 不一致）

进度条的 `Radius.circular(2)` 低于 M3 shape 量表（<extraSmall 4），按审核结论保持不动。

## 测试

- ✅ `flutter analyze` — No issues found
- ✅ `flutter test` — 95/95 全绿
- ✅ 手动验证（复用既有登录会话，未重复登录）：AppBar 在内容滚动到其下方时出现淡紫色 surface tint，回到顶部恢复平面

### 演示

<a href="https://cursor.com/agents/bc-77694499-b735-4e6a-8f28-96ca145ce198/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fm3_appbar_scroll_tint_restored.mp4"><img src="https://cursor.com/artifacts/c/art-c92e68d0-48d6-4176-aa31-d0acbc242233" alt="m3_appbar_scroll_tint_restored.mp4" /></a>

| 静止（顶部，平面） | 滚动后（surface tint） |
|---|---|
| ![AppBar 静止平面](https://cursor.com/artifacts/c/art-31a6798c-a248-4b92-ac90-e1a6924e7728) | ![AppBar 滚动着色](https://cursor.com/artifacts/c/art-6a448699-4849-471a-b58d-172e303347ce) |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77694499-b735-4e6a-8f28-96ca145ce198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77694499-b735-4e6a-8f28-96ca145ce198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

