### PR TITLE
fix(security): address audit high and medium findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 | WebView | webview_flutter | ^4.7.0 |
 | HTML 渲染 | flutter_html | ^3.0.0-beta.2 |
 | Cookie 管理 | dio_cookie_manager / cookie_jar | ^3.1.1 / ^4.0.8 |
+| 安全存储 | flutter_secure_storage | ^10.x |
+| 加密 | cryptography | ^2.x |
 | 包管理 | flutter pub | — |
 | 运行环境 | Flutter SDK >=3.4 | 支持 Web / Android / iOS / Windows / macOS / Linux |
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,17 @@ flutter run
 dart run scripts/proxy_server.dart
 ```
 
-代理运行在 `http://localhost:19080`，会自动转发请求到 `https://stage1st.com` 并处理 CORS 头。
+代理默认运行在 `http://localhost:19080`（可通过 `--dart-define=PROXY_PORT=` 修改），会自动转发请求到 `https://stage1st.com` 并处理 CORS 头。
+
+启动时会生成或校验访问令牌 `PROXY_AUTH_TOKEN`。若未通过 `--dart-define` 传入，代理会打印随机 token，Flutter Web 需使用相同值：
+
+```bash
+# 终端 1
+dart run scripts/proxy_server.dart
+
+# 终端 2（将 token 替换为代理启动时打印的值）
+flutter run -d chrome --dart-define=PROXY_AUTH_TOKEN=your_token_here
+```
 
 ## 架构说明
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <application
         android:label="s1_app"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>保存论坛图片到相册需要访问照片库</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,11 +1,15 @@
+import 'dart:typed_data';
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:talker_flutter/talker_flutter.dart';
+import 'config/resource_domains.dart';
 import 'providers/settings_provider.dart';
 import 'screens/home_screen.dart';
 import 'screens/login_screen.dart';
+import 'screens/login_webview_screen.dart';
 import 'screens/forum_list_screen.dart';
 import 'screens/thread_detail_screen.dart';
 import 'screens/compose_screen.dart';
@@ -15,6 +19,35 @@ import 'screens/reading_history_screen.dart';
 import 'screens/image_viewer_screen.dart';
 import 'services/talker.dart';
 import 'theme/app_theme.dart';
+
+ImageViewerScreen? _parseImageViewerRoute(GoRouterState state) {
+  Map<String, dynamic>? args;
+  if (state.extra is Map<String, dynamic>) {
+    args = state.extra! as Map<String, dynamic>;
+  }
+
+  final urlFromQuery = state.uri.queryParameters['url'];
+  final imageUrl = args?['imageUrl'] as String? ?? urlFromQuery;
+  if (imageUrl == null || imageUrl.isEmpty) return null;
+
+  final typeStr = state.uri.queryParameters['type'] ??
+      args?['resourceType']?.toString();
+  ResourceType resourceType = ResourceType.publicAsset;
+  if (typeStr != null) {
+    resourceType = ResourceType.values.firstWhere(
+      (t) => t.name == typeStr,
+      orElse: () => ResourceType.publicAsset,
+    );
+  } else if (args?['resourceType'] is ResourceType) {
+    resourceType = args!['resourceType'] as ResourceType;
+  }
+
+  return ImageViewerScreen(
+    imageUrl: imageUrl,
+    imageBytes: args?['imageBytes'] as Uint8List?,
+    resourceType: resourceType,
+  );
+}
 
 final _router = GoRouter(
   initialLocation: '/',
@@ -46,6 +79,10 @@ final _router = GoRouter(
       builder: (context, state) => const LoginScreen(),
     ),
     GoRoute(
+      path: '/login-webview',
+      builder: (context, state) => const LoginWebViewScreen(),
+    ),
+    GoRoute(
       path: '/compose',
       builder: (context, state) => ComposeScreen(
         tid: state.uri.queryParameters['tid'],
@@ -67,11 +104,23 @@ final _router = GoRouter(
     GoRoute(
       path: '/image-viewer',
       builder: (context, state) {
-        final args = state.extra as Map<String, dynamic>;
-        return ImageViewerScreen(
-          imageUrl: args['imageUrl'] as String,
-          imageBytes: args['imageBytes'],
-          resourceType: args['resourceType'],
+        final screen = _parseImageViewerRoute(state);
+        if (screen != null) return screen;
+        return Scaffold(
+          appBar: AppBar(title: const Text('图片')),
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text('无法加载图片'),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () => context.pop(),
+                  child: const Text('返回'),
+                ),
+              ],
+            ),
+          ),
         );
       },
     ),

--- a/lib/config/env_config.dart
+++ b/lib/config/env_config.dart
@@ -1,0 +1,30 @@
+class EnvConfig {
+  EnvConfig._();
+
+  /// Web 端 CORS 代理端口（默认 19080，需与 proxy_server 一致）
+  static const int proxyPort = int.fromEnvironment(
+    'PROXY_PORT',
+    defaultValue: 19080,
+  );
+
+  /// 代理访问令牌（需与 proxy_server 启动时一致）
+  static const String proxyAuthToken = String.fromEnvironment(
+    'PROXY_AUTH_TOKEN',
+    defaultValue: '',
+  );
+
+  /// 请求超时（秒，默认 20）
+  static const int connectTimeoutSeconds = int.fromEnvironment(
+    'CONNECT_TIMEOUT',
+    defaultValue: 20,
+  );
+
+  /// 响应超时（秒，默认 30）
+  static const int receiveTimeoutSeconds = int.fromEnvironment(
+    'RECEIVE_TIMEOUT',
+    defaultValue: 30,
+  );
+}
+
+/// 代理请求认证头名称（客户端与 proxy_server 共用）
+const String proxyAuthHeader = 'X-S1-Proxy-Token';

--- a/lib/config/resource_domains.dart
+++ b/lib/config/resource_domains.dart
@@ -5,6 +5,8 @@
 /// 新增/修改域名只需改动此文件。
 library resource_domains;
 
+import 'env_config.dart';
+
 // ──────────────────────── 资源类型 ────────────────────────
 
 enum ResourceType {
@@ -42,8 +44,8 @@ class DomainRule {
 class ResourceDomains {
   ResourceDomains._();
 
-  /// 代理服务器端口
-  static const int proxyPort = 19080;
+  /// 代理服务器端口（与 [EnvConfig.proxyPort] 统一）
+  static int get proxyPort => EnvConfig.proxyPort;
 
   /// API 主域名（用于代理默认路由）
   static const String apiHost = 'stage1st.com';
@@ -101,5 +103,21 @@ class ResourceDomains {
   static String getReferer(String host) {
     final rule = match(host);
     return rule?.referer ?? defaultReferer;
+  }
+
+  /// `/img-proxy` 允许转发的目标 URL（仅 https + 白名单域名）
+  static bool isAllowedProxyTarget(Uri uri) {
+    if (uri.scheme != 'https') return false;
+    if (uri.userInfo.isNotEmpty) return false;
+    if (uri.host.isEmpty) return false;
+    // 拒绝 IP 字面量
+    if (RegExp(r'^\d{1,3}(\.\d{1,3}){3}$').hasMatch(uri.host)) return false;
+    if (uri.host.contains(':')) return false;
+    // 仅标准 HTTPS 端口（或未指定端口）
+    if (uri.hasPort && uri.port != 443) return false;
+
+    final rule = match(uri.host);
+    return rule?.type == ResourceType.authImage ||
+        rule?.type == ResourceType.publicAsset;
   }
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/user.dart';
 import '../services/auth_service.dart';
 import '../services/http_client.dart';
+import '../services/reading_history_service.dart';
+import 'reading_history_provider.dart';
 
 final authServiceProvider = Provider<AuthService>((ref) {
   return AuthService(httpClient: ref.watch(httpClientProvider));
@@ -26,55 +28,70 @@ class AuthState {
 
 class AuthNotifier extends StateNotifier<AuthState> {
 
-  AuthNotifier(this._authService) : super(AuthState()) {
+  AuthNotifier(this._authService, this._ref) : super(AuthState()) {
     _init();
   }
   final AuthService _authService;
+  final Ref _ref;
 
   Future<void> _init() async {
     final ok = await _authService.checkSession();
     if (ok) {
-      state = AuthState(
-        isLoggedIn: true,
-        username: _authService.currentUser?.username,
-        user: _authService.currentUser,
-      );
+      _syncStateFromService();
     }
+  }
+
+  void _syncStateFromService() {
+    state = AuthState(
+      isLoggedIn: true,
+      username: _authService.currentUser?.username,
+      user: _authService.currentUser,
+    );
+    _maybeMigrateGuestHistory();
+  }
+
+  void _maybeMigrateGuestHistory() {
+    final uid = _authService.currentUser?.uid;
+    if (uid == null || uid.isEmpty) return;
+    final box = _ref.read(readingBoxProvider);
+    ReadingHistoryService(box, uid).migrateGuestRecords(uid);
+    _ref.read(readingHistoryProvider.notifier).refresh();
   }
 
   void setLoggedIn(String username) {
     _authService.setLoggedIn(username);
-    state = AuthState(
-      isLoggedIn: true,
-      username: username,
-      user: _authService.currentUser,
-    );
-    unawaited(_authService.fetchProfile().then((user) {
-      if (user != null) {
-        try {
-          state = state.copyWith(user: user, username: user.username);
-        } catch (_) {}
-      }
-    }),);
+    _syncStateFromService();
   }
 
   Future<String?> login(String username, String password) async {
     final error = await _authService.login(username, password);
     if (error == null) {
-      state = AuthState(
-        isLoggedIn: true,
-        username: _authService.currentUser?.username,
-        user: _authService.currentUser,
-      );
-      unawaited(_authService.fetchProfile().then((user) {
-        if (user != null) {
-          try {
-            state = state.copyWith(user: user, username: user.username);
-          } catch (_) {}
-        }
-      }),);
+      _syncStateFromService();
+      // profile 由 AuthService.login 内 _fetchProfile 拉取，此处轮询等待 uid
+      await _waitForProfile();
     }
     return error;
+  }
+
+  Future<String?> completeWebViewLogin() async {
+    final error = await _authService.completeWebViewLogin();
+    if (error == null) {
+      _syncStateFromService();
+      _maybeMigrateGuestHistory();
+    }
+    return error;
+  }
+
+  Future<void> _waitForProfile() async {
+    for (var i = 0; i < 20; i++) {
+      final user = _authService.currentUser;
+      if (user != null && user.uid.isNotEmpty) {
+        state = state.copyWith(user: user, username: user.username);
+        _maybeMigrateGuestHistory();
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
   }
 
   Future<void> refreshProfile() async {
@@ -82,16 +99,17 @@ class AuthNotifier extends StateNotifier<AuthState> {
     if (user != null) {
       try {
         state = state.copyWith(user: user, username: user.username);
+        _maybeMigrateGuestHistory();
       } catch (_) {}
     }
   }
 
-  void logout() {
-    _authService.logout();
+  Future<void> logout() async {
+    await _authService.logout();
     state = AuthState();
   }
 }
 
 final authStateProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  return AuthNotifier(ref.watch(authServiceProvider));
+  return AuthNotifier(ref.watch(authServiceProvider), ref);
 });

--- a/lib/providers/post_provider.dart
+++ b/lib/providers/post_provider.dart
@@ -64,7 +64,7 @@ final pollVoteCacheProvider = Provider.family<PollVoteCache, String>((ref, uid) 
   return PollVoteCache(Hive.box('cache'), uid);
 });
 
-final postProvider = StateNotifierProvider.family<
+final postProvider = StateNotifierProvider.autoDispose.family<
     PostNotifier, AsyncValue<PostListState>, String>(
   (ref, tid) => PostNotifier(
     tid: tid,

--- a/lib/providers/thread_list_provider.dart
+++ b/lib/providers/thread_list_provider.dart
@@ -27,7 +27,7 @@ class ThreadListState {
   }
 }
 
-final threadListProvider = StateNotifierProvider.family<
+final threadListProvider = StateNotifierProvider.autoDispose.family<
     ThreadListNotifier, AsyncValue<ThreadListState>, String>(
   (ref, fid) => ThreadListNotifier(
     fid: fid,

--- a/lib/screens/compose_screen.dart
+++ b/lib/screens/compose_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../services/api_service.dart';
-import '../services/http_client.dart';
+import '../providers/post_provider.dart';
 import '../utils/s1_snack_bar.dart';
 
 class ComposeScreen extends ConsumerStatefulWidget {
@@ -31,7 +30,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
     setState(() => _isSubmitting = true);
 
     try {
-      final apiService = ApiService(ref.read(httpClientProvider));
+      final apiService = ref.read(apiServiceProvider);
       final error = await apiService.sendPost(
         fid: widget.fid ?? '',
         tid: widget.tid ?? '',
@@ -51,7 +50,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
         S1SnackBar.show(context, message: '$e', bottomClearance: 16);
       }
     } finally {
-      setState(() => _isSubmitting = false);
+      if (mounted) setState(() => _isSubmitting = false);
     }
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -190,7 +190,13 @@ class _ForumCategoryTile extends ConsumerWidget {
                     .read(settingsProvider.notifier)
                     .toggleForumCollapse(category.fid)
                 : null,
-            child: Container(
+            child: Semantics(
+              button: hasSubs,
+              expanded: hasSubs ? !isCollapsed : null,
+              label: category.name,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 48),
+                child: Container(
               width: double.infinity,
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               color: scheme.surfaceContainer,
@@ -231,6 +237,8 @@ class _ForumCategoryTile extends ConsumerWidget {
                 ],
               ),
             ),
+          ),
+        ),
           ),
           // 子版块列表
           AnimatedSize(

--- a/lib/screens/image_viewer_screen.dart
+++ b/lib/screens/image_viewer_screen.dart
@@ -1,10 +1,19 @@
+import 'dart:io' show Platform;
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gal/gal.dart';
+
 import '../config/resource_domains.dart';
+import '../services/http_client.dart';
+import '../utils/s1_snack_bar.dart';
 import '../widgets/web_image_stub.dart'
     if (dart.library.html) '../widgets/web_image_html.dart';
 
-class ImageViewerScreen extends StatelessWidget {
+class ImageViewerScreen extends ConsumerStatefulWidget {
   const ImageViewerScreen({
     super.key,
     required this.imageUrl,
@@ -13,30 +22,130 @@ class ImageViewerScreen extends StatelessWidget {
   });
 
   final String imageUrl;
-  final dynamic imageBytes;
+  final Uint8List? imageBytes;
   final ResourceType resourceType;
+
+  @override
+  ConsumerState<ImageViewerScreen> createState() => _ImageViewerScreenState();
+}
+
+class _ImageViewerScreenState extends ConsumerState<ImageViewerScreen> {
+  Uint8List? _fetchedBytes;
+  bool _downloading = false;
+
+  bool get _canSaveToGallery =>
+      !kIsWeb && !Platform.isLinux;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.imageBytes == null) {
+      _tryFetchBytes().then((bytes) {
+        if (bytes != null && mounted) {
+          setState(() => _fetchedBytes = bytes);
+        }
+      });
+    }
+  }
+
+  Future<Uint8List?> _tryFetchBytes() async {
+    try {
+      final httpClient = ref.read(httpClientProvider);
+      final response = await httpClient.get(
+        widget.imageUrl,
+        options: Options(responseType: ResponseType.bytes),
+      );
+      return Uint8List.fromList(response.data as List<int>);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String get _fileName {
+    final uri = Uri.parse(widget.imageUrl);
+    final name = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : 'image';
+    return name.contains('.') ? name : '$name.jpg';
+  }
+
+  Uint8List? get _effectiveBytes => widget.imageBytes ?? _fetchedBytes;
+
+  Future<void> _downloadImage(BuildContext context) async {
+    if (_downloading || !_canSaveToGallery) return;
+    setState(() => _downloading = true);
+
+    final messenger = ScaffoldMessenger.of(context);
+
+    try {
+      Uint8List bytes;
+      if (_effectiveBytes != null) {
+        bytes = _effectiveBytes!;
+      } else {
+        final fetched = await _tryFetchBytes();
+        if (fetched == null) throw StateError('无法获取图片数据');
+        bytes = fetched;
+      }
+
+      await Gal.putImageBytes(bytes, name: _fileName);
+
+      if (context.mounted) {
+        messenger.clearSnackBars();
+        S1SnackBar.show(context, message: '已保存到相册', bottomClearance: 16);
+      }
+    } catch (e) {
+      if (context.mounted) {
+        messenger.clearSnackBars();
+        S1SnackBar.show(context, message: '下载失败: $e', bottomClearance: 16);
+      }
+    } finally {
+      if (mounted) setState(() => _downloading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final provider = imageBytes != null
-        ? MemoryImage(imageBytes) as ImageProvider
-        : NetworkImage(imageUrl);
+    final provider = _effectiveBytes != null
+        ? MemoryImage(_effectiveBytes!)
+        : NetworkImage(widget.imageUrl) as ImageProvider;
 
     return Scaffold(
       backgroundColor: colorScheme.inverseSurface,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
+        scrolledUnderElevation: 0,
         foregroundColor: colorScheme.onInverseSurface,
+        actions: [
+          if (kIsWeb)
+            IconButton(
+              tooltip: '下载',
+              onPressed: () {
+                downloadImageWeb(widget.imageUrl, _fileName);
+                S1SnackBar.show(context, message: '下载已开始', bottomClearance: 16);
+              },
+              icon: const Icon(Icons.download_outlined),
+            )
+          else if (_canSaveToGallery)
+            IconButton(
+              tooltip: '保存到相册',
+              onPressed: _downloading ? null : () => _downloadImage(context),
+              icon: _downloading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.download_outlined),
+            ),
+        ],
       ),
       extendBodyBehindAppBar: true,
       body: Center(
         child: InteractiveViewer(
           minScale: 0.5,
           maxScale: 4.0,
-          child: resourceType == ResourceType.publicAsset && kIsWeb
-              ? buildWebImage(imageUrl, width: 800, height: 800)
+          child: widget.resourceType == ResourceType.publicAsset && kIsWeb
+              ? buildWebImage(widget.imageUrl, width: 800, height: 800)
               : Image(image: provider),
         ),
       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -19,6 +22,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   bool _isLoading = false;
   bool _obscurePassword = true;
   String? _errorMessage;
+
+  bool get _isLinuxNative => !kIsWeb && Platform.isLinux;
 
   @override
   void dispose() {
@@ -61,102 +66,166 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    if (!kIsWeb) {
+      return _buildNativeLogin(context);
+    }
+    return _buildWebFormLogin(context);
+  }
+
+  Widget _buildNativeLogin(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
     return Scaffold(
       appBar: AppBar(
-        elevation: 0,
         title: const Text('登录 Stage1st'),
       ),
       body: Center(
         child: SingleChildScrollView(
-          padding: const EdgeInsets.all(24.0),
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: Card(
+              color: scheme.surfaceContainerHighest,
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      '安全登录',
+                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      _isLinuxNative
+                          ? 'Linux 桌面端暂不支持 WebView 登录，请使用 Web 版本。'
+                          : '密码仅在官方登录页内输入，不会经过本应用代码。',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: scheme.onSurfaceVariant,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 32),
+                    if (!_isLinuxNative)
+                      FilledButton(
+                        onPressed: () => context.push('/login-webview'),
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                        ),
+                        child: const Text('在 WebView 中登录'),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWebFormLogin(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('登录 Stage1st'),
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400),
             child: Card(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,
               child: Padding(
-                padding: const EdgeInsets.all(32.0),
+                padding: const EdgeInsets.all(32),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    '欢迎回来',
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
+                  children: [
+                    Text(
+                      '欢迎回来',
+                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '登录您的 Stage1st 账号',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 32),
+                    if (_errorMessage != null) ...[
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 10,
+                          horizontal: 14,
                         ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    '登录您的 Stage1st 账号',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.errorContainer,
+                          borderRadius: S1Shape.small,
                         ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 32),
-                  if (_errorMessage != null) ...[
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 10, horizontal: 14,
+                        child: Text(
+                          _errorMessage!,
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Theme.of(context).colorScheme.onErrorContainer,
+                              ),
                         ),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.errorContainer,
-                        borderRadius: S1Shape.small,
                       ),
-                      child: Text(
-                        _errorMessage!,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.onErrorContainer,
-                        ),
+                      const SizedBox(height: 16),
+                    ],
+                    TextField(
+                      controller: _usernameController,
+                      focusNode: _usernameFocus,
+                      decoration: const InputDecoration(
+                        labelText: '用户名',
+                        prefixIcon: Icon(Icons.person),
                       ),
+                      keyboardType: TextInputType.text,
+                      textInputAction: TextInputAction.next,
+                      onSubmitted: (_) => _passwordFocus.requestFocus(),
                     ),
                     const SizedBox(height: 16),
-                  ],
-                  TextField(
-                    controller: _usernameController,
-                    focusNode: _usernameFocus,
-                    decoration: const InputDecoration(
-                      labelText: '用户名',
-                      prefixIcon: Icon(Icons.person),
-                    ),
-                    keyboardType: TextInputType.text,
-                    textInputAction: TextInputAction.next,
-                    onSubmitted: (_) => _passwordFocus.requestFocus(),
-                  ),
-                  const SizedBox(height: 16),
-                  TextField(
-                    controller: _passwordController,
-                    focusNode: _passwordFocus,
-                    decoration: InputDecoration(
-                      labelText: '密码',
-                      prefixIcon: const Icon(Icons.lock),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscurePassword ? Icons.visibility_off : Icons.visibility),
-                        tooltip: _obscurePassword ? '显示密码' : '隐藏密码',
-                        onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+                    TextField(
+                      controller: _passwordController,
+                      focusNode: _passwordFocus,
+                      decoration: InputDecoration(
+                        labelText: '密码',
+                        prefixIcon: const Icon(Icons.lock),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _obscurePassword ? Icons.visibility_off : Icons.visibility,
+                          ),
+                          tooltip: _obscurePassword ? '显示密码' : '隐藏密码',
+                          onPressed: () =>
+                              setState(() => _obscurePassword = !_obscurePassword),
+                        ),
                       ),
+                      obscureText: _obscurePassword,
+                      onSubmitted: (_) => _handleLogin(),
                     ),
-                    obscureText: _obscurePassword,
-                    onSubmitted: (_) => _handleLogin(),
-                  ),
-                  const SizedBox(height: 24),
-                  FilledButton(
-                    onPressed: _isLoading ? null : _handleLogin,
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: _isLoading ? null : _handleLogin,
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                      child: _isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('登录'),
                     ),
-                    child: _isLoading
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                            ),
-                          )
-                        : const Text('登录'),
-                  ),
-                ],
+                  ],
                 ),
               ),
             ),

--- a/lib/screens/login_webview_screen.dart
+++ b/lib/screens/login_webview_screen.dart
@@ -1,0 +1,127 @@
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../config/api_config.dart';
+import '../config/resource_domains.dart';
+import '../providers/auth_provider.dart';
+
+/// 原生平台 WebView 登录：密码仅在 WebView 内输入，不经过 Flutter 代码。
+class LoginWebViewScreen extends ConsumerStatefulWidget {
+  const LoginWebViewScreen({super.key});
+
+  @override
+  ConsumerState<LoginWebViewScreen> createState() => _LoginWebViewScreenState();
+}
+
+class _LoginWebViewScreenState extends ConsumerState<LoginWebViewScreen> {
+  late final WebViewController _controller;
+  final _cookieManager = WebViewCookieManager();
+  bool _isLoading = true;
+  bool _isCompleting = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (_) => _setLoading(true),
+          onPageFinished: (_) {
+            _setLoading(false);
+            _tryCompleteLogin();
+          },
+          onWebResourceError: (error) {
+            _setLoading(false);
+            setState(() {
+              _errorMessage = '页面加载失败: ${error.description}';
+            });
+          },
+        ),
+      )
+      ..loadRequest(Uri.parse(ApiConfig.loginUrl));
+  }
+
+  void _setLoading(bool loading) {
+    if (!mounted) return;
+    setState(() => _isLoading = loading);
+  }
+
+  Future<void> _tryCompleteLogin() async {
+    if (_isCompleting) return;
+
+    final cookies = await _cookieManager.getCookies(
+      domain: Uri.parse('https://${ResourceDomains.apiHost}'),
+    );
+    final hasAuth = cookies.any(
+      (c) =>
+          c.name.startsWith(ResourceDomains.cookiePrefix) &&
+          c.name.endsWith('auth') &&
+          c.value.isNotEmpty,
+    );
+    if (!hasAuth) return;
+
+    _isCompleting = true;
+    setState(() {
+      _errorMessage = null;
+      _isLoading = true;
+    });
+
+    final authService = ref.read(authServiceProvider);
+    final jarCookies = cookies
+        .map(
+          (c) => Cookie(c.name, c.value)
+            ..domain = c.domain
+            ..path = c.path,
+        )
+        .toList();
+    await authService.importWebViewCookies(jarCookies);
+
+    final error = await ref.read(authStateProvider.notifier).completeWebViewLogin();
+    if (!mounted) return;
+
+    if (error == null) {
+      context.go('/');
+    } else {
+      setState(() {
+        _isCompleting = false;
+        _isLoading = false;
+        _errorMessage = error;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('登录 Stage1st'),
+      ),
+      body: Column(
+        children: [
+          if (_errorMessage != null)
+            MaterialBanner(
+              content: Text(_errorMessage!),
+              backgroundColor: scheme.errorContainer,
+              leading: Icon(Icons.error_outline, color: scheme.onErrorContainer),
+              actions: [
+                TextButton(
+                  onPressed: () => setState(() => _errorMessage = null),
+                  child: const Text('关闭'),
+                ),
+              ],
+            ),
+          if (_isLoading)
+            const LinearProgressIndicator(minHeight: 2),
+          Expanded(child: WebViewWidget(controller: _controller)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -77,9 +77,9 @@ class ProfileBody extends ConsumerWidget {
             icon: Icons.logout,
             label: '退出登录',
             color: colorScheme.error,
-            onTap: () {
-              ref.read(authStateProvider.notifier).logout();
-              context.go('/');
+            onTap: () async {
+              await ref.read(authStateProvider.notifier).logout();
+              if (context.mounted) context.go('/');
             },
           ),
         const SizedBox(height: 24),

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -43,6 +43,10 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   /// 记录阅读进度：写库 + 刷新历史列表（使列表卡片/历史页/资料计数实时更新）。
   /// readCount 只在本次进入详情页首帧 +1（isNewVisit 由 _hasRecordedInitialVisit 守卫）。
   void _recordProgress(PostListState state) {
+    final auth = ref.read(authStateProvider);
+    if (auth.isLoggedIn && (auth.user?.uid.isEmpty ?? true)) {
+      return;
+    }
     ref.read(readingHistoryServiceProvider).updateProgress(
           tid: widget.tid,
           page: state.currentPage,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import '../config/api_config.dart';
 import '../models/thread.dart';
 import '../models/post.dart';
@@ -202,8 +203,11 @@ class ApiService {
     return json;
   }
 
-  /// 纯 API 登录：返回 null 表示成功，否则返回错误信息
+  /// 纯 API 登录：返回 null 表示成功，否则返回错误信息（仅 Web 端）
   Future<String?> login(String username, String password) async {
+    if (!kIsWeb) {
+      throw UnsupportedError('Native login must use WebView');
+    }
     try {
       // 1. 发起 GET 请求以获取当前会话的 formhash
       final loginInitUrl = buildApiUrl(module: ApiConfig.moduleLogin);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import '../config/env_config.dart';
 import '../models/user.dart';
 import 'http_client.dart';
 import 'api_service.dart';
@@ -24,6 +26,9 @@ class AuthService {
   }
 
   Future<String?> login(String username, String password) async {
+    if (!kIsWeb) {
+      throw UnsupportedError('Native login must use WebView');
+    }
     try {
       final apiService = ApiService(_httpClient);
       final error = await apiService.login(username, password);
@@ -59,10 +64,49 @@ class AuthService {
     return await _fetchProfile();
   }
 
-  void logout() {
+  Future<void> logout() async {
+    if (kIsWeb && EnvConfig.proxyAuthToken.isNotEmpty) {
+      try {
+        final proxyUrl =
+            'http://localhost:${EnvConfig.proxyPort}/proxy/session/clear';
+        await _httpClient.post(
+          proxyUrl,
+          options: Options(
+            headers: {proxyAuthHeader: EnvConfig.proxyAuthToken},
+          ),
+        );
+      } catch (e, st) {
+        talker.handle(e, st, 'Clear proxy session failed');
+      }
+    }
     _currentUser = null;
     _isLoggedIn = false;
-    _httpClient.cookieJar.deleteAll();
+    await _httpClient.cookieJar.deleteAll();
+  }
+
+  /// WebView 登录成功后同步 Cookie 并拉取资料
+  Future<String?> completeWebViewLogin() async {
+    try {
+      final ok = await checkSession();
+      if (!ok) {
+        return '登录未完成，请重试';
+      }
+      final profile = await _fetchProfile();
+      if (profile == null || profile.uid.isEmpty) {
+        return '获取用户资料失败';
+      }
+      return null;
+    } catch (e, st) {
+      talker.handle(e, st, 'WebView login completion failed');
+      return '登录失败: $e';
+    }
+  }
+
+  /// 将 WebView 读取的 Cookie 写入本地 CookieJar（原生平台）
+  Future<void> importWebViewCookies(List<Cookie> cookies) async {
+    if (kIsWeb) return;
+    final uri = Uri.parse('https://stage1st.com/2b/');
+    await _httpClient.cookieJar.saveFromResponse(uri, cookies);
   }
 
   Future<bool> checkSession() async {

--- a/lib/services/encrypted_cookie_storage.dart
+++ b/lib/services/encrypted_cookie_storage.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:cryptography/dart.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// 使用 AES-256-GCM 加密 [FileStorage] 落盘内容，密钥存于安全存储。
+class EncryptedCookieStorage {
+  EncryptedCookieStorage._();
+
+  static const _keyStorageId = 's1_cookie_encryption_key';
+  static const _secureStorage = FlutterSecureStorage();
+  static final DartAesGcm _algorithm = DartAesGcm();
+
+  /// 创建带加密读写的 [FileStorage]。
+  static Future<FileStorage> create(String dir) async {
+    final secretKeyData = await _loadOrCreateKeyData();
+    return buildEncryptedStorage(dir, secretKeyData);
+  }
+
+  /// 测试用：使用固定密钥构建加密存储。
+  @visibleForTesting
+  static FileStorage buildEncryptedStorage(String dir, SecretKeyData secretKeyData) {
+    final storage = FileStorage(dir);
+
+    storage.readPreHandler = (Uint8List bytes) {
+      if (bytes.isEmpty) return null;
+      try {
+        final box = SecretBox.fromConcatenation(
+          bytes,
+          nonceLength: _algorithm.nonceLength,
+          macLength: _algorithm.macAlgorithm.macLength,
+        );
+        final decrypted =
+            _algorithm.decryptSync(box, secretKeyData: secretKeyData);
+        return utf8.decode(decrypted);
+      } catch (_) {
+        return null;
+      }
+    };
+
+    storage.writePreHandler = (String value) {
+      final nonce = _algorithm.newNonce();
+      final box = _algorithm.encryptSync(
+        utf8.encode(value),
+        secretKeyData: secretKeyData,
+        nonce: nonce,
+      );
+      return box.concatenation();
+    };
+
+    return storage;
+  }
+
+  static Future<SecretKeyData> _loadOrCreateKeyData() async {
+    var encoded = await _secureStorage.read(key: _keyStorageId);
+    if (encoded == null || encoded.isEmpty) {
+      final random = Random.secure();
+      final keyBytes = List<int>.generate(32, (_) => random.nextInt(256));
+      encoded = base64Url.encode(keyBytes);
+      await _secureStorage.write(key: _keyStorageId, value: encoded);
+      return SecretKeyData(keyBytes);
+    }
+    return SecretKeyData(base64Url.decode(encoded));
+  }
+}

--- a/lib/services/http_client.dart
+++ b/lib/services/http_client.dart
@@ -6,8 +6,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import '../config/constants.dart';
+import '../config/env_config.dart';
 import '../config/resource_domains.dart';
 import 'formhash_service.dart';
+import 'encrypted_cookie_storage.dart';
 
 class S1HttpClient {
 
@@ -17,7 +19,7 @@ class S1HttpClient {
   final List<DateTime> _requestTimestamps = [];
   final Ref _ref;
 
-  static const String _proxyUrl = 'http://localhost:${ResourceDomains.proxyPort}';
+  static String get _proxyUrl => 'http://localhost:${EnvConfig.proxyPort}';
   static bool get _isWeb => kIsWeb;
 
   PersistCookieJar get cookieJar => _cookieJar;
@@ -29,9 +31,8 @@ class S1HttpClient {
     } else {
       final appDocDir = await getApplicationDocumentsDirectory();
       final cookiePath = '${appDocDir.path}/.cookies/';
-      _cookieJar = PersistCookieJar(
-        storage: FileStorage(cookiePath),
-      );
+      final storage = await EncryptedCookieStorage.create(cookiePath);
+      _cookieJar = PersistCookieJar(storage: storage);
     }
 
     final headers = <String, String>{
@@ -43,8 +44,8 @@ class S1HttpClient {
     }
 
     _dio = Dio(BaseOptions(
-      connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 15),
+      connectTimeout: const Duration(seconds: EnvConfig.connectTimeoutSeconds),
+      receiveTimeout: const Duration(seconds: EnvConfig.receiveTimeoutSeconds),
       headers: headers,
     ),);
 
@@ -91,17 +92,23 @@ class S1HttpClient {
 
           if (rule != null && ResourceDomains.requiresProxy(uri.host)) {
             if (rule.type == ResourceType.authImage) {
-              // 需认证的图片走 /img-proxy
-              options.path = '$_proxyUrl/img-proxy?url=${Uri.encodeComponent(options.path)}';
+              options.path =
+                  '$_proxyUrl/img-proxy?url=${Uri.encodeComponent(options.path)}';
             } else if (rule.type == ResourceType.api) {
-              // API 走默认路由
               final path = uri.path;
               final queryParts = options.path.split('?');
-              final rawQuery = queryParts.length > 1 ? queryParts.sublist(1).join('?') : '';
-              options.path = '$_proxyUrl$path${rawQuery.isNotEmpty ? '?$rawQuery' : ''}';
+              final rawQuery =
+                  queryParts.length > 1 ? queryParts.sublist(1).join('?') : '';
+              options.path =
+                  '$_proxyUrl$path${rawQuery.isNotEmpty ? '?$rawQuery' : ''}';
             }
           }
-          // publicAsset 不重写，浏览器直加载
+
+          // 代理请求注入访问令牌
+          if (options.path.startsWith(_proxyUrl) &&
+              EnvConfig.proxyAuthToken.isNotEmpty) {
+            options.headers[proxyAuthHeader] = EnvConfig.proxyAuthToken;
+          }
         }
 
         handler.next(options);

--- a/lib/services/reading_history_service.dart
+++ b/lib/services/reading_history_service.dart
@@ -93,6 +93,28 @@ class ReadingHistoryService {
     await _box.deleteAll(keys);
   }
 
+  /// 将 guest_* 记录迁移到真实 uid 前缀（登录后调用一次）
+  void migrateGuestRecords(String uid) {
+    if (uid.isEmpty) return;
+    const guestPrefix = 'guest_';
+    final targetPrefix = '${uid}_';
+    final toMigrate = <String, Map<dynamic, dynamic>>{};
+    for (final key in _box.keys) {
+      if (key is! String || !key.startsWith(guestPrefix)) continue;
+      final tid = key.substring(guestPrefix.length);
+      final value = _box.get(key);
+      if (value == null) continue;
+      toMigrate['$targetPrefix$tid'] = Map<dynamic, dynamic>.from(value);
+    }
+    for (final entry in toMigrate.entries) {
+      _box.put(entry.key, entry.value);
+    }
+    final guestKeys = _box.keys
+        .where((k) => k is String && k.startsWith(guestPrefix))
+        .toList();
+    _box.deleteAll(guestKeys);
+  }
+
   /// LRU 淘汰：仅按当前用户计数，超限删除最旧（`lastReadAt` 最小）。
   void _evictIfNeeded() {
     final keys = _box.keys.where(_belongsToUser).toList();

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -79,7 +79,11 @@ class AppTheme {
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
-      appBarTheme: const AppBarTheme(centerTitle: true),
+      appBarTheme: const AppBarTheme(
+        centerTitle: true,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+      ),
       cardTheme: const CardThemeData(
         shape: S1Shape.cardShape,
         elevation: 0,

--- a/lib/widgets/image_viewer.dart
+++ b/lib/widgets/image_viewer.dart
@@ -36,6 +36,8 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
   static final LinkedHashMap<String, Uint8List> _cache = LinkedHashMap();
   static final Map<String, MemoryImage> _providerCache = {};
   static const int _maxCacheEntries = 200;
+  static const int _maxCacheBytes = 50 * 1024 * 1024;
+  static int _cacheBytes = 0;
 
   bool _loading = false;
   Uint8List? _bytes;
@@ -92,6 +94,24 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
     _loadViaDio();
   }
 
+  void _putInCache(String url, Uint8List data) {
+    if (_cache.containsKey(url)) {
+      _cacheBytes -= _cache[url]!.length;
+      _cache.remove(url);
+      _providerCache.remove(url);
+    }
+    _cache[url] = data;
+    _providerCache[url] = MemoryImage(data);
+    _cacheBytes += data.length;
+
+    while (_cache.length > _maxCacheEntries || _cacheBytes > _maxCacheBytes) {
+      final evicted = _cache.keys.first;
+      _cacheBytes -= _cache[evicted]!.length;
+      _cache.remove(evicted);
+      _providerCache.remove(evicted);
+    }
+  }
+
   Future<void> _loadViaDio() async {
     if (!mounted) return;
     setState(() {
@@ -108,13 +128,7 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
       final data = response.data as Uint8List;
 
       // 写入 LRU 缓存
-      _cache[widget.imageUrl] = data;
-      _providerCache[widget.imageUrl] = MemoryImage(data);
-      if (_cache.length > _maxCacheEntries) {
-        final evicted = _cache.keys.first;
-        _cache.remove(evicted);
-        _providerCache.remove(evicted);
-      }
+      _putInCache(widget.imageUrl, data);
 
       setState(() {
         _bytes = data;
@@ -149,13 +163,17 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
 
     // Web 公开资源：原生 <img>，无 CORS
     if (_resourceType == ResourceType.publicAsset && kIsWeb) {
-      return GestureDetector(
-        onTap: () => _showFullScreen(context),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final w = constraints.hasBoundedWidth ? constraints.maxWidth : 300.0;
-            return buildWebImage(widget.imageUrl, width: w, height: w);
-          },
+      return Semantics(
+        button: true,
+        label: '查看大图',
+        child: GestureDetector(
+          onTap: () => _showFullScreen(context),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final w = constraints.hasBoundedWidth ? constraints.maxWidth : 300.0;
+              return buildWebImage(widget.imageUrl, width: w, height: w);
+            },
+          ),
         ),
       );
     }
@@ -183,9 +201,12 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
   }
 
   Widget _buildImage(ImageProvider provider) {
-    return GestureDetector(
-      onTap: () => _showFullScreen(context),
-      child: Image(
+    return Semantics(
+      button: true,
+      label: '查看大图',
+      child: GestureDetector(
+        onTap: () => _showFullScreen(context),
+        child: Image(
         key: ValueKey(widget.imageUrl),
         image: provider,
         fit: BoxFit.contain,
@@ -210,6 +231,7 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
         },
         errorBuilder: (_, __, ___) => _buildError(),
       ),
+      ),
     );
   }
 
@@ -232,15 +254,25 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
   }
 
   Widget _buildError() {
-    return GestureDetector(
-      onTap: _loadViaDio,
-      child: Container(
-        height: 80,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceContainerHighest,
-          borderRadius: S1Shape.small,
+    return Semantics(
+      button: true,
+      label: '重试加载图片',
+      child: GestureDetector(
+        onTap: _loadViaDio,
+        child: Container(
+          height: 80,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+            borderRadius: S1Shape.small,
+          ),
+          child: Center(
+            child: Icon(
+              Icons.broken_image_outlined,
+              size: 24,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
         ),
-        child: Center(child: Icon(Icons.broken_image_outlined, size: 24, color: Theme.of(context).colorScheme.outline)),
       ),
     );
   }
@@ -262,10 +294,14 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
   }
 
   void _showFullScreen(BuildContext context) {
-    context.push('/image-viewer', extra: {
-      'imageUrl': widget.imageUrl,
-      'imageBytes': _bytes,
-      'resourceType': _resourceType,
-    },);
+    final encodedUrl = Uri.encodeComponent(widget.imageUrl);
+    context.push(
+      '/image-viewer?url=$encodedUrl&type=${_resourceType.name}',
+      extra: {
+        'imageUrl': widget.imageUrl,
+        'imageBytes': _bytes,
+        'resourceType': _resourceType,
+      },
+    );
   }
 }

--- a/lib/widgets/quote_block.dart
+++ b/lib/widgets/quote_block.dart
@@ -54,7 +54,10 @@ class QuoteBlock extends StatelessWidget {
           if (author != null || parsedLink != null)
             Material(
               color: Colors.transparent,
-              child: InkWell(
+              child: Semantics(
+                button: parsedLink != null,
+                label: parsedLink != null ? '跳转到引用帖子' : null,
+                child: InkWell(
                 borderRadius: S1Shape.small,
                 onTap: parsedLink != null
                     ? () => _navigateToPost(context, parsedLink)
@@ -92,6 +95,7 @@ class QuoteBlock extends StatelessWidget {
                     ],
                   ),
                 ),
+              ),
               ),
             ),
           Padding(

--- a/lib/widgets/web_image_html.dart
+++ b/lib/widgets/web_image_html.dart
@@ -43,3 +43,13 @@ String _toCssFit(BoxFit fit) {
       return 'contain';
   }
 }
+
+/// Web 端触发浏览器下载图片
+void downloadImageWeb(String url, String fileName) {
+  final anchor = html.AnchorElement(href: url)
+    ..download = fileName
+    ..target = '_blank';
+  html.document.body?.append(anchor);
+  anchor.click();
+  anchor.remove();
+}

--- a/lib/widgets/web_image_stub.dart
+++ b/lib/widgets/web_image_stub.dart
@@ -3,3 +3,7 @@ import 'package:flutter/material.dart';
 Widget buildWebImage(String url, {double? width, double? height, BoxFit fit = BoxFit.contain}) {
   return Image.network(url, width: width, height: height, fit: fit);
 }
+
+void downloadImageWeb(String url, String fileName) {
+  // 非 Web 平台无操作
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import dynamic_color
+import flutter_secure_storage_darwin
 import gal
 import package_info_plus
 import share_plus
@@ -14,6 +15,7 @@ import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -26,6 +26,8 @@
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>保存论坛图片到相册需要访问照片库</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   csslib:
     dependency: transitive
     description:
@@ -310,6 +318,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   talker_dio_logger: ^5.1.17
   dynamic_color: ^1.8.1
   gal: ^2.3.0
+  flutter_secure_storage: ^10.3.1
+  cryptography: ^2.9.0
 
 dev_dependencies:
   flutter_test:

--- a/scripts/proxy_server.dart
+++ b/scripts/proxy_server.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
+import '../lib/config/env_config.dart';
 import '../lib/config/resource_domains.dart';
 
 const String mobileUserAgent =
@@ -13,97 +16,24 @@ final Map<String, String> _cookieJar = {};
 /// img-proxy 404 缓存（避免对无头像用户重复请求）
 final Set<String> _imgProxy404Cache = {};
 
+/// 允许的 CORS Origin（仅 localhost）
+final _localhostOrigin = RegExp(r'^http://localhost(:\d+)?$');
+
+late final String _proxyAuthToken;
+
 void main() async {
-  final server = await HttpServer.bind('localhost', ResourceDomains.proxyPort);
-  print('Proxy on http://localhost:${ResourceDomains.proxyPort}');
+  _proxyAuthToken = _resolveAuthToken();
+  final port = ResourceDomains.proxyPort;
+  final server = await HttpServer.bind('localhost', port);
+  print('Proxy on http://localhost:$port');
+  if (EnvConfig.proxyAuthToken.isEmpty) {
+    print('PROXY_AUTH_TOKEN (auto-generated): $_proxyAuthToken');
+    print('Pass to Flutter: --dart-define=PROXY_AUTH_TOKEN=$_proxyAuthToken');
+  }
 
   await for (final req in server) {
     try {
-      final res = req.response;
-
-      if (req.method == 'OPTIONS') {
-        _cors(req, res);
-        res.statusCode = 204;
-        await res.close();
-        continue;
-      }
-
-      final isImgProxy = req.uri.path.startsWith('/img-proxy');
-
-      // 确定目标 URL
-      Uri target;
-      if (isImgProxy) {
-        final targetUrl = req.uri.queryParameters['url'];
-        if (targetUrl == null) {
-          res.statusCode = 400;
-          await res.close();
-          continue;
-        }
-        // 404 缓存命中：直接返回，不请求上游
-        if (_imgProxy404Cache.contains(targetUrl)) {
-          _cors(req, res);
-          res.statusCode = 404;
-          await res.close();
-          continue;
-        }
-        target = Uri.parse(targetUrl);
-      } else {
-        var path = req.uri.path;
-        final query = req.uri.query;
-        if (!path.startsWith('/2b/')) path = '/2b$path';
-        target = Uri.parse('https://${ResourceDomains.apiHost}$path${query.isNotEmpty ? '?$query' : ''}');
-      }
-
-      final client = HttpClient()
-        ..badCertificateCallback = (_, __, ___) => true;
-      final upReq = await client.openUrl(req.method, target);
-
-      if (isImgProxy) {
-        // 认证图片：根据 resource_domains 配置决定请求头
-        upReq.headers.set('Host', target.host);
-        upReq.headers.set('Referer', ResourceDomains.getReferer(target.host));
-        upReq.headers.set('User-Agent', mobileUserAgent);
-        upReq.headers.set('Accept', 'image/*,*/*;q=0.8');
-        _attachCookies(upReq);
-      } else {
-        // API：转发原始请求头 + Cookie
-        final ct = req.headers.contentType;
-        if (ct != null) upReq.headers.set('Content-Type', ct.toString());
-        upReq.headers.set('User-Agent', mobileUserAgent);
-        _attachCookies(upReq);
-      }
-
-      final body = await req.fold<List<int>>([], (a, b) => a..addAll(b));
-      if (body.isNotEmpty) {
-        upReq.bufferOutput = true;
-        upReq.headers.set('Content-Length', body.length.toString());
-        upReq.add(body);
-      }
-
-      print('>>> ${req.method} $target');
-      final upRes = await upReq.close();
-      print('<<< ${upRes.statusCode}');
-
-      // 存储上游响应的 Cookie
-      _storeCookies(upRes.headers['set-cookie']);
-
-      final bytes = await upRes.fold<List<int>>([], (a, b) => a..addAll(b));
-      client.close(force: true);
-
-      // img-proxy 404 写入缓存
-      if (isImgProxy && upRes.statusCode == 404) {
-        _imgProxy404Cache.add(req.uri.queryParameters['url']!);
-        print('  404 cached: ${req.uri.queryParameters['url']}');
-      }
-
-      res.statusCode = upRes.statusCode;
-      _cors(req, res);
-
-      // 转发 set-cookie 给浏览器
-      _forwardCookies(res, upRes.headers['set-cookie']);
-
-      res.add(bytes);
-      await res.close();
+      await _handleRequest(req);
     } catch (e, st) {
       print('ERROR: $e\n$st');
       try {
@@ -115,7 +45,156 @@ void main() async {
   }
 }
 
-/// 从 Cookie 罐中加载匹配的 Cookie 并附加到请求
+String _resolveAuthToken() {
+  if (EnvConfig.proxyAuthToken.isNotEmpty) {
+    return EnvConfig.proxyAuthToken;
+  }
+  final random = Random.secure();
+  final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+  return base64Url.encode(bytes);
+}
+
+Future<void> _handleRequest(HttpRequest req) async {
+  final res = req.response;
+
+  if (req.method == 'OPTIONS') {
+    if (!_applyCors(req, res)) {
+      res.statusCode = 403;
+      await res.close();
+      return;
+    }
+    res.statusCode = 204;
+    await res.close();
+    return;
+  }
+
+  if (!_verifyAuthToken(req)) {
+    res.statusCode = 403;
+    res.write('Invalid proxy token');
+    await res.close();
+    return;
+  }
+
+  // 注销：清除代理端会话
+  if (req.method == 'POST' && req.uri.path == '/proxy/session/clear') {
+    _cookieJar.clear();
+    _imgProxy404Cache.clear();
+    if (!_applyCors(req, res)) {
+      res.statusCode = 403;
+      await res.close();
+      return;
+    }
+    res.statusCode = 204;
+    await res.close();
+    print('Session cleared');
+    return;
+  }
+
+  final isImgProxy = req.uri.path.startsWith('/img-proxy');
+
+  Uri target;
+  ResourceType? imgResourceType;
+  if (isImgProxy) {
+    final targetUrl = req.uri.queryParameters['url'];
+    if (targetUrl == null) {
+      res.statusCode = 400;
+      await res.close();
+      return;
+    }
+    if (_imgProxy404Cache.contains(targetUrl)) {
+      _applyCors(req, res);
+      res.statusCode = 404;
+      await res.close();
+      return;
+    }
+    target = Uri.parse(targetUrl);
+    if (!ResourceDomains.isAllowedProxyTarget(target)) {
+      res.statusCode = 403;
+      res.write('Target URL not allowed');
+      await res.close();
+      return;
+    }
+    imgResourceType = ResourceDomains.match(target.host)?.type;
+  } else {
+    var path = req.uri.path;
+    final query = req.uri.query;
+    if (!path.startsWith('/2b/')) path = '/2b$path';
+    target = Uri.parse(
+      'https://${ResourceDomains.apiHost}$path${query.isNotEmpty ? '?$query' : ''}',
+    );
+  }
+
+  final client = HttpClient();
+  final upReq = await client.openUrl(req.method, target);
+
+  if (isImgProxy) {
+    upReq.headers.set('Host', target.host);
+    upReq.headers.set('Referer', ResourceDomains.getReferer(target.host));
+    upReq.headers.set('User-Agent', mobileUserAgent);
+    upReq.headers.set('Accept', 'image/*,*/*;q=0.8');
+    if (imgResourceType == ResourceType.authImage) {
+      _attachCookies(upReq);
+    }
+  } else {
+    final ct = req.headers.contentType;
+    if (ct != null) upReq.headers.set('Content-Type', ct.toString());
+    upReq.headers.set('User-Agent', mobileUserAgent);
+    _attachCookies(upReq);
+  }
+
+  final body = await req.fold<List<int>>([], (a, b) => a..addAll(b));
+  if (body.isNotEmpty) {
+    upReq.bufferOutput = true;
+    upReq.headers.set('Content-Length', body.length.toString());
+    upReq.add(body);
+  }
+
+  print('>>> ${req.method} $target');
+  final upRes = await upReq.close();
+  print('<<< ${upRes.statusCode}');
+
+  _storeCookies(upRes.headers['set-cookie']);
+
+  final bytes = await upRes.fold<List<int>>([], (a, b) => a..addAll(b));
+  client.close(force: true);
+
+  if (isImgProxy && upRes.statusCode == 404) {
+    _imgProxy404Cache.add(req.uri.queryParameters['url']!);
+    print('  404 cached: ${req.uri.queryParameters['url']}');
+  }
+
+  res.statusCode = upRes.statusCode;
+  _applyCors(req, res);
+  _forwardCookies(res, upRes.headers['set-cookie']);
+
+  res.add(bytes);
+  await res.close();
+}
+
+bool _verifyAuthToken(HttpRequest req) {
+  final token = req.headers.value(proxyAuthHeader);
+  return token != null && token == _proxyAuthToken;
+}
+
+bool _applyCors(HttpRequest req, HttpResponse res) {
+  final origin = req.headers.value('Origin');
+  if (origin != null && _localhostOrigin.hasMatch(origin)) {
+    res.headers.set('Access-Control-Allow-Origin', origin);
+    res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.headers.set(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Cookie, $proxyAuthHeader',
+    );
+    res.headers.set('Access-Control-Allow-Credentials', 'true');
+    return true;
+  }
+  if (origin == null) {
+    // 非浏览器直连（如 curl）无需 CORS
+    return true;
+  }
+  return false;
+}
+
 void _attachCookies(HttpClientRequest req) {
   final matched = <String>[];
   for (final entry in _cookieJar.entries) {
@@ -129,7 +208,6 @@ void _attachCookies(HttpClientRequest req) {
   }
 }
 
-/// 从响应的 Set-Cookie 头解析并存储到 Cookie 罐
 void _storeCookies(List<String>? setCookieHeaders) {
   if (setCookieHeaders == null) return;
   for (final header in setCookieHeaders) {
@@ -145,7 +223,6 @@ void _storeCookies(List<String>? setCookieHeaders) {
   }
 }
 
-/// 转发 set-cookie 给浏览器（清理 domain/secure 限制）
 void _forwardCookies(HttpResponse res, List<String>? setCookieHeaders) {
   if (setCookieHeaders == null) return;
   for (final v in setCookieHeaders) {
@@ -156,12 +233,4 @@ void _forwardCookies(HttpResponse res, List<String>? setCookieHeaders) {
     }).toList();
     res.headers.add('set-cookie', cleanedParts.join('; '));
   }
-}
-
-void _cors(HttpRequest req, HttpResponse res) {
-  final origin = req.headers.value('Origin') ?? 'http://localhost:${ResourceDomains.proxyPort}';
-  res.headers.set('Access-Control-Allow-Origin', origin);
-  res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Cookie');
-  res.headers.set('Access-Control-Allow-Credentials', 'true');
 }

--- a/test/app_image_viewer_route_test.dart
+++ b/test/app_image_viewer_route_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets('image-viewer route without extra shows fallback', (tester) async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/image-viewer',
+          builder: (context, state) {
+            final url = state.uri.queryParameters['url'];
+            if (url == null || url.isEmpty) {
+              return Scaffold(
+                appBar: AppBar(title: const Text('图片')),
+                body: Center(
+                  child: FilledButton(
+                    onPressed: () {},
+                    child: const Text('返回'),
+                  ),
+                ),
+              );
+            }
+            return Scaffold(body: Text(url));
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(routerConfig: router),
+    );
+    router.go('/image-viewer');
+    await tester.pumpAndSettle();
+
+    expect(find.text('返回'), findsOneWidget);
+    expect(find.text('无法加载图片'), findsNothing);
+  });
+}

--- a/test/config/resource_domains_test.dart
+++ b/test/config/resource_domains_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/config/resource_domains.dart';
+
+void main() {
+  group('ResourceDomains.isAllowedProxyTarget', () {
+    test('allows https auth image host', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('https://img.stage1st.com/avatar.jpg'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('allows https public asset host', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('https://static.stage1st.com/emoticon.gif'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects http scheme', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('http://img.stage1st.com/a.jpg'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects unknown host', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('https://evil.com/steal'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects IP literal host', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('https://127.0.0.1/secret'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects api host for img-proxy', () {
+      expect(
+        ResourceDomains.isAllowedProxyTarget(
+          Uri.parse('https://stage1st.com/2b/api'),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/services/encrypted_cookie_storage_test.dart
+++ b/test/services/encrypted_cookie_storage_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/services/encrypted_cookie_storage.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('s1_cookie_test_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('encrypted storage round-trips cookie data', () async {
+    final keyData = SecretKeyData(List<int>.filled(32, 1));
+    final storage =
+        EncryptedCookieStorage.buildEncryptedStorage(tempDir.path, keyData);
+    await storage.init(true, true);
+
+    const payload = 'session_cookie_data';
+    await storage.write('test_key', payload);
+
+    final read = await storage.read('test_key');
+    expect(read, payload);
+  });
+}

--- a/test/services/reading_history_service_test.dart
+++ b/test/services/reading_history_service_test.dart
@@ -118,4 +118,16 @@ void main() {
     expect(s.getRecord('t1'), isNull);
     expect(s.getRecord('t2'), isNotNull);
   });
+
+  test('migrateGuestRecords moves guest keys to uid prefix', () {
+    final guest = service('guest');
+    record(guest, '42');
+    expect(guest.getRecord('42'), isNotNull);
+
+    final user = ReadingHistoryService(box, '10001');
+    user.migrateGuestRecords('10001');
+
+    expect(guest.getRecord('42'), isNull);
+    expect(user.getRecord('42'), isNotNull);
+  });
 }

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+void main() {
+  test('AppBar uses zero scrolledUnderElevation', () {
+    final theme = AppTheme.lightTheme('purple');
+    expect(theme.appBarTheme.elevation, 0);
+    expect(theme.appBarTheme.scrolledUnderElevation, 0);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <gal/gal_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -14,6 +15,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   GalPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GalPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
+  flutter_secure_storage_windows
   gal
   share_plus
   url_launcher_windows


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the security audit blocking issues (5 HIGH, multiple MEDIUM) and remaining M3/a11y debt.

### HIGH fixes

- **Proxy hardening** (`scripts/proxy_server.dart`): HTTPS allowlist for `/img-proxy`, restore TLS verification, localhost-only CORS, `X-S1-Proxy-Token` auth, auth cookies only for `authImage` targets
- **Web logout**: `POST /proxy/session/clear` + async `AuthService.logout()` clears proxy session
- **Native login boundary**: `LoginWebViewScreen` for `!kIsWeb`; API password login restricted to Web only
- **Cookie encryption**: `EncryptedCookieStorage` (AES-256-GCM + `flutter_secure_storage` key)
- **Gal permissions**: iOS/macOS `NSPhotoLibraryAddUsageDescription`, Android storage/media permissions, Linux save disabled

### MEDIUM fixes

- `EnvConfig.proxyPort` unified with proxy server (`PROXY_PORT`)
- `/image-viewer` supports query params + safe fallback when `extra` is null
- `postProvider` / `threadListProvider` use `autoDispose`
- `ComposeScreen` uses `apiServiceProvider`; `mounted` guard in `finally`
- Duplicate profile fetch removed; `migrateGuestRecords` for reading history
- Image cache byte budget (50MB); `ImageViewerScreen` uses `S1HttpClient`

### M3 / a11y

- `AppBar.scrolledUnderElevation: 0`
- Semantics on image viewer, quote links, forum collapse headers

## Test plan

- [x] `flutter analyze` (0 errors)
- [x] `flutter test` — 134 tests pass
- [ ] Manual Web: proxy token + login/logout session clear
- [ ] Manual native: WebView login + image save permissions

## Dev notes

Web dev requires matching `PROXY_AUTH_TOKEN` between proxy and Flutter (see README). Proxy prints token on first start if not configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0460edb6-c873-4ff4-9d18-0d5172107361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0460edb6-c873-4ff4-9d18-0d5172107361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

