### PR TITLE
chore(deps): P0 flutter_html 稳定约束与补丁升级

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_resolvers:
     dependency: transitive
     description:
@@ -1049,10 +1049,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: e4d3474277c5043f5f3100ed27d94ad693abfd5c602b0221c719a4497e4ba1e4
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   webview_flutter_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   go_router: ^14.0.0
   html: ^0.15.4
   url_launcher: ^6.2.5
-  flutter_html: ^3.0.0-beta.2
+  flutter_html: ^3.0.0
   package_info_plus: ^10.2.0
   talker_flutter: ^5.1.17
   talker_dio_logger: ^5.1.17


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

技术栈现代化 **P0**：低风险依赖对齐。

- `flutter_html`: `^3.0.0-beta.2` → `^3.0.0`（lock 本就已是稳定 3.0.0）
- `flutter pub upgrade` 补丁：`webview_flutter` 4.14.0 → 4.14.1，`build_daemon` 4.1.1 → 4.1.2
- **未**升级 Riverpod / go_router / lints（属后续 PR）

## Test plan

- [x] `flutter test` — 240 passed
- [ ] `flutter analyze` — 仓库原有 5 个 unused_* warning，与本 PR 无关
- [ ] 冒烟：帖子 HTML 渲染仍正常

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

