### PR TITLE
feat(state): P2 Riverpod 3 Notifier 全量迁移

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -157,7 +157,7 @@ class S1App extends ConsumerWidget {
 
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (ref.read(dynamicColorAvailableProvider) != hasDynamic) {
-            ref.read(dynamicColorAvailableProvider.notifier).state = hasDynamic;
+            ref.read(dynamicColorAvailableProvider.notifier).setAvailable(hasDynamic);
           }
         });
 

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/user.dart';
 import '../services/auth_service.dart';
@@ -11,8 +12,8 @@ final authServiceProvider = Provider<AuthService>((ref) {
 });
 
 class AuthState {
-
   AuthState({this.isLoggedIn = false, this.username, this.user});
+
   final bool isLoggedIn;
   final String? username;
   final User? user;
@@ -26,13 +27,14 @@ class AuthState {
   }
 }
 
-class AuthNotifier extends StateNotifier<AuthState> {
-
-  AuthNotifier(this._authService, this._ref) : super(AuthState()) {
-    _init();
+class AuthNotifier extends Notifier<AuthState> {
+  @override
+  AuthState build() {
+    unawaited(_init());
+    return AuthState();
   }
-  final AuthService _authService;
-  final Ref _ref;
+
+  AuthService get _authService => ref.read(authServiceProvider);
 
   Future<void> _init() async {
     final ok = await _authService.checkSession();
@@ -53,8 +55,8 @@ class AuthNotifier extends StateNotifier<AuthState> {
   void _maybeMigrateGuestHistory() {
     final uid = _authService.currentUser?.uid;
     if (uid == null || uid.isEmpty) return;
-    _ref.read(readingHistoryServiceProvider).migrateGuestRecords(uid);
-    _ref.read(readingHistoryProvider.notifier).refresh();
+    ref.read(readingHistoryServiceProvider).migrateGuestRecords(uid);
+    ref.read(readingHistoryProvider.notifier).refresh();
   }
 
   void setLoggedIn(String username) {
@@ -67,7 +69,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
     if (error == null) {
       _syncStateFromService();
       await _waitForProfile();
-      _ref.invalidate(forumListProvider);
+      ref.invalidate(forumListProvider);
     }
     return error;
   }
@@ -95,16 +97,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   Future<void> logout() async {
-    try {
-      await _authService.logout();
-      state = AuthState();
-      _ref.invalidate(forumListProvider);
-    } catch (e) {
-      rethrow;
-    }
+    await _authService.logout();
+    state = AuthState();
+    ref.invalidate(forumListProvider);
   }
+
+  /// Test helper: seed auth state without calling the network.
+  void debugSetState(AuthState next) => state = next;
 }
 
-final authStateProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  return AuthNotifier(ref.watch(authServiceProvider), ref);
-});
+final authStateProvider =
+    NotifierProvider<AuthNotifier, AuthState>(AuthNotifier.new);

--- a/lib/providers/messages_segment_provider.dart
+++ b/lib/providers/messages_segment_provider.dart
@@ -2,7 +2,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../config/api_config.dart';
 
 /// 消息页当前分段：0 = 我的消息，1 = 我的提醒。
-final messagesSegmentProvider = StateProvider<int>((ref) => 0);
+class MessagesSegment extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void select(int index) => state = index;
+}
+
+final messagesSegmentProvider =
+    NotifierProvider<MessagesSegment, int>(MessagesSegment.new);
 
 String messagesBrowserUrl(int segment) {
   if (segment == 1) {

--- a/lib/providers/notice_list_provider.dart
+++ b/lib/providers/notice_list_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../models/message_list_result.dart';
 import '../models/notice_item.dart';
 import '../services/api_service.dart';
 import '../services/http_client.dart';
@@ -28,36 +27,21 @@ class NoticeListState {
   }
 }
 
-final noticeListProvider = StateNotifierProvider.autoDispose<
-    NoticeListNotifier, AsyncValue<NoticeListState>>(
-  (ref) => NoticeListNotifier(
-    apiService: ApiService(ref.watch(httpClientProvider)),
-  ),
-);
+class NoticeListNotifier extends AsyncNotifier<NoticeListState> {
+  NoticeListNotifier({this.seed});
 
-class NoticeListNotifier extends StateNotifier<AsyncValue<NoticeListState>> {
-  NoticeListNotifier({
-    required ApiService apiService,
-    AsyncValue<NoticeListState>? initialState,
-  })  : _apiService = apiService,
-        super(initialState ?? const AsyncValue.loading()) {
-    if (initialState == null) {
-      _initLoad();
-    }
+  final NoticeListState? seed;
+
+  @override
+  Future<NoticeListState> build() async {
+    if (seed != null) return seed!;
+    return _loadPage(1);
   }
 
-  final ApiService _apiService;
+  ApiService get _apiService => ApiService(ref.watch(httpClientProvider));
 
-  Future<void> _initLoad() async {
-    try {
-      final result = await _apiService.getNoticeList(page: 1);
-      state = AsyncValue.data(_toState(result));
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
-  }
-
-  NoticeListState _toState(NoticeListResult result) {
+  Future<NoticeListState> _loadPage(int page) async {
+    final result = await _apiService.getNoticeList(page: page);
     return NoticeListState(
       items: result.items,
       currentPage: result.currentPage,
@@ -66,25 +50,21 @@ class NoticeListNotifier extends StateNotifier<AsyncValue<NoticeListState>> {
   }
 
   Future<void> goToPage(int page) async {
-    final current = state.valueOrNull;
-    try {
-      final result = await _apiService.getNoticeList(page: page);
-      state = AsyncValue.data(_toState(result));
-    } catch (_) {
-      if (current != null) {
-        state = AsyncValue.data(current);
-      }
+    final current = state.asData?.value;
+    state = await AsyncValue.guard(() => _loadPage(page));
+    if (state.hasError && current != null) {
+      state = AsyncValue.data(current);
     }
   }
 
   Future<void> refresh() async {
-    final currentPage = state.valueOrNull?.currentPage ?? 1;
+    final currentPage = state.asData?.value.currentPage ?? 1;
     state = const AsyncValue.loading();
-    try {
-      final result = await _apiService.getNoticeList(page: currentPage);
-      state = AsyncValue.data(_toState(result));
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
+    state = await AsyncValue.guard(() => _loadPage(currentPage));
   }
 }
+
+final noticeListProvider =
+    AsyncNotifierProvider.autoDispose<NoticeListNotifier, NoticeListState>(
+  NoticeListNotifier.new,
+);

--- a/lib/providers/pm_list_provider.dart
+++ b/lib/providers/pm_list_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../models/message_list_result.dart';
 import '../models/private_message_item.dart';
 import '../services/api_service.dart';
 import '../services/http_client.dart';
@@ -28,36 +27,21 @@ class PmListState {
   }
 }
 
-final pmListProvider = StateNotifierProvider.autoDispose<
-    PmListNotifier, AsyncValue<PmListState>>(
-  (ref) => PmListNotifier(
-    apiService: ApiService(ref.watch(httpClientProvider)),
-  ),
-);
+class PmListNotifier extends AsyncNotifier<PmListState> {
+  PmListNotifier({this.seed});
 
-class PmListNotifier extends StateNotifier<AsyncValue<PmListState>> {
-  PmListNotifier({
-    required ApiService apiService,
-    AsyncValue<PmListState>? initialState,
-  })  : _apiService = apiService,
-        super(initialState ?? const AsyncValue.loading()) {
-    if (initialState == null) {
-      _initLoad();
-    }
+  final PmListState? seed;
+
+  @override
+  Future<PmListState> build() async {
+    if (seed != null) return seed!;
+    return _loadPage(1);
   }
 
-  final ApiService _apiService;
+  ApiService get _apiService => ApiService(ref.watch(httpClientProvider));
 
-  Future<void> _initLoad() async {
-    try {
-      final result = await _apiService.getPmList(page: 1);
-      state = AsyncValue.data(_toState(result));
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
-  }
-
-  PmListState _toState(PmListResult result) {
+  Future<PmListState> _loadPage(int page) async {
+    final result = await _apiService.getPmList(page: page);
     return PmListState(
       items: result.items,
       currentPage: result.currentPage,
@@ -67,6 +51,11 @@ class PmListNotifier extends StateNotifier<AsyncValue<PmListState>> {
 
   Future<void> refresh() async {
     state = const AsyncValue.loading();
-    await _initLoad();
+    state = await AsyncValue.guard(() => _loadPage(1));
   }
 }
+
+final pmListProvider =
+    AsyncNotifierProvider.autoDispose<PmListNotifier, PmListState>(
+  PmListNotifier.new,
+);

--- a/lib/providers/post_provider.dart
+++ b/lib/providers/post_provider.dart
@@ -8,8 +8,8 @@ import '../services/http_client.dart';
 import '../services/poll_vote_cache.dart';
 import '../services/rate_log_service.dart';
 import 'settings_provider.dart';
-class PostListState {
 
+class PostListState {
   PostListState({
     this.posts = const [],
     this.currentPage = 1,
@@ -24,34 +24,20 @@ class PostListState {
     this.rateLogs = const {},
     this.allowReply = true,
   });
+
   final List<Post> posts;
   final int currentPage;
   final int totalPages;
   final String? threadSubject;
   final String? threadFid;
-
-  /// 每页帖数（来自 API `ppp`，缺省用 fallback 40）
   final int perPage;
-
-  /// 帖子总回复数（来自 API `thread.replies`）
   final int totalReplies;
-
-  /// 投票帖数据（仅 `thread.special == 1` 时有值）
   final ThreadPoll? poll;
-
-  /// 当前激活的作者筛选 ID（服务端过滤），null 表示不过滤
   final String? filterAuthorId;
-
-  /// 当前筛选的作者名（用于 UI 提示）
   final String? filterAuthorName;
-
-  /// 评分记录（key = pid）
   final Map<String, PostRateLog> rateLogs;
-
-  /// 是否允许回复（来自 API `thread.allowreply`）
   final bool allowReply;
 
-  /// 是否正在按作者筛选
   bool get isFiltering => filterAuthorId != null;
 
   PostListState copyWith({
@@ -78,8 +64,10 @@ class PostListState {
       perPage: perPage ?? this.perPage,
       totalReplies: totalReplies ?? this.totalReplies,
       poll: poll ?? this.poll,
-      filterAuthorId: clearFilter ? null : (filterAuthorId ?? this.filterAuthorId),
-      filterAuthorName: clearFilter ? null : (filterAuthorName ?? this.filterAuthorName),
+      filterAuthorId:
+          clearFilter ? null : (filterAuthorId ?? this.filterAuthorId),
+      filterAuthorName:
+          clearFilter ? null : (filterAuthorName ?? this.filterAuthorName),
       rateLogs: rateLogs ?? this.rateLogs,
       allowReply: allowReply ?? this.allowReply,
     );
@@ -98,37 +86,18 @@ final pollVoteCacheProvider = Provider.family<PollVoteCache, String>((ref, uid) 
   return PollVoteCache(ref.watch(localDataProvider), uid);
 });
 
-final postProvider = StateNotifierProvider.autoDispose.family<
-    PostNotifier, AsyncValue<PostListState>, String>(
-  (ref, tid) => PostNotifier(
-    tid: tid,
-    apiService: ref.watch(apiServiceProvider),
-    rateLogService: ref.watch(rateLogServiceProvider),
-    ref: ref,
-  ),
-);
+class PostNotifier extends AsyncNotifier<PostListState> {
+  PostNotifier(this.tid);
 
-class PostNotifier extends StateNotifier<AsyncValue<PostListState>> {
-
-  PostNotifier({
-    required this.tid,
-    required ApiService apiService,
-    required RateLogService rateLogService,
-    required Ref ref,
-  })  : _apiService = apiService,
-        _rateLogService = rateLogService,
-        _ref = ref,
-        super(const AsyncValue.loading()) {
-    _loadPage(1, showFullLoading: true);
-  }
   final String tid;
-  final ApiService _apiService;
-  final RateLogService _rateLogService;
-  final Ref _ref;
-
-  /// 服务端按作者筛选：null 表示不过滤
   String? _filterAuthorId;
   String? _filterAuthorName;
+
+  ApiService get _apiService => ref.watch(apiServiceProvider);
+  RateLogService get _rateLogService => ref.watch(rateLogServiceProvider);
+
+  @override
+  Future<PostListState> build() => _loadPage(1);
 
   ThreadPoll? _pollWithUserVotes(
     Map<String, dynamic> variables,
@@ -137,96 +106,86 @@ class PostNotifier extends StateNotifier<AsyncValue<PostListState>> {
     if (poll == null) return null;
     final uid = variables['member_uid']?.toString() ?? '';
     if (uid.isEmpty || uid == '0') return poll;
-    final votes = _ref.read(pollVoteCacheProvider(uid)).getVotes(tid);
+    final votes = ref.read(pollVoteCacheProvider(uid)).getVotes(tid);
     return votes.isEmpty ? poll : poll.withUserVotes(votes);
   }
 
-  Future<void> _loadPage(int page, {bool showFullLoading = false}) async {
-    final previous = state.valueOrNull;
-    if (showFullLoading) {
-      state = const AsyncValue.loading();
-    }
-    try {
-      final detailFuture = _apiService.getThreadDetail(
-        tid,
-        page: page,
-        authorId: _filterAuthorId,
-      );
-      final rateLogFuture = _rateLogService.fetchRateLogs(tid, page: page);
+  Future<PostListState> _loadPage(int page) async {
+    final detailFuture = _apiService.getThreadDetail(
+      tid,
+      page: page,
+      authorId: _filterAuthorId,
+    );
+    final rateLogFuture = _rateLogService.fetchRateLogs(tid, page: page);
 
-      final results = await Future.wait<Object>([detailFuture, rateLogFuture]);
-      final result = results[0] as Map<String, dynamic>;
-      final rateLogs = results[1] as Map<String, PostRateLog>;
+    final results = await Future.wait<Object>([detailFuture, rateLogFuture]);
+    final result = results[0] as Map<String, dynamic>;
+    final rateLogs = results[1] as Map<String, PostRateLog>;
 
-      final posts = ApiService.parsePostList(result);
+    final posts = ApiService.parsePostList(result);
+    final variables = result['Variables'] as Map<String, dynamic>? ?? {};
+    final thread = variables['thread'] as Map<String, dynamic>? ?? {};
+    final perPage = int.tryParse(variables['ppp']?.toString() ?? '') ??
+        S1Constants.postsPerPageFallback;
+    final totalReplies = int.tryParse(thread['replies']?.toString() ?? '') ?? 0;
+    final totalPosts = totalReplies + 1;
+    final totalPages = (totalPosts / perPage).ceil().clamp(1, 9999);
+    final allowReply = thread['allowreply']?.toString() != '0';
 
-      // 统一提取 variables / thread，避免重复遍历 JSON
-      final variables = result['Variables'] as Map<String, dynamic>? ?? {};
-      final thread = variables['thread'] as Map<String, dynamic>? ?? {};
-      // 每页帖数：API 字段 ppp（viewthread），拿不到时用 fallback 40（不是 30）
-      final perPage = int.tryParse(variables['ppp']?.toString() ?? '') ??
-          S1Constants.postsPerPageFallback;
-      final totalReplies = int.tryParse(thread['replies']?.toString() ?? '') ?? 0;
-      final totalPosts = totalReplies + 1; // 主楼 + 回复
-      final totalPages = (totalPosts / perPage).ceil().clamp(1, 9999);
-      final allowReply = thread['allowreply']?.toString() != '0';
-
-      state = AsyncValue.data(PostListState(
-        posts: posts,
-        currentPage: page,
-        totalPages: totalPages,
-        threadSubject: thread['subject']?.toString(),
-        threadFid: thread['fid']?.toString(),
-        perPage: perPage,
-        totalReplies: totalReplies,
-        poll: page == 1
-            ? _pollWithUserVotes(variables, ApiService.parsePoll(result))
-            : null,
-        filterAuthorId: _filterAuthorId,
-        filterAuthorName: _filterAuthorName,
-        rateLogs: rateLogs,
-        allowReply: allowReply,
-      ),);
-    } catch (e, st) {
-      if (showFullLoading || previous == null) {
-        state = AsyncValue.error(e, st);
-      }
-    }
+    return PostListState(
+      posts: posts,
+      currentPage: page,
+      totalPages: totalPages,
+      threadSubject: thread['subject']?.toString(),
+      threadFid: thread['fid']?.toString(),
+      perPage: perPage,
+      totalReplies: totalReplies,
+      poll: page == 1
+          ? _pollWithUserVotes(variables, ApiService.parsePoll(result))
+          : null,
+      filterAuthorId: _filterAuthorId,
+      filterAuthorName: _filterAuthorName,
+      rateLogs: rateLogs,
+      allowReply: allowReply,
+    );
   }
 
-  /// 定位特定回复，自动跳转到对应页。
   Future<void> locatePid(String pid) async {
     state = const AsyncValue.loading();
     final page = await _apiService.locatePostPage(tid, pid);
-    await _loadPage(page, showFullLoading: true);
+    state = await AsyncValue.guard(() => _loadPage(page));
   }
 
   Future<void> goToPage(int page) async {
-    await _loadPage(page);
+    final previous = state.asData?.value;
+    state = await AsyncValue.guard(() => _loadPage(page));
+    if (state.hasError && previous != null) {
+      state = AsyncValue.data(previous);
+    }
   }
 
-  /// 按指定作者筛选帖子（服务端过滤，翻页保持生效）
-  void filterByAuthor(String authorId, String authorName) {
+  Future<void> filterByAuthor(String authorId, String authorName) async {
     _filterAuthorId = authorId;
     _filterAuthorName = authorName;
-    _loadPage(1);
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _loadPage(1));
   }
 
-  /// 取消作者筛选
-  void clearFilter() {
+  Future<void> clearFilter() async {
     _filterAuthorId = null;
     _filterAuthorName = null;
-    _loadPage(1);
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _loadPage(1));
   }
 
   Future<void> refresh() async {
-    final current = state.valueOrNull?.currentPage ?? 1;
-    await _loadPage(current, showFullLoading: true);
+    final current = state.asData?.value.currentPage ?? 1;
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _loadPage(current));
   }
 
-  /// 异步加载特定帖子的完整评分记录
   Future<void> loadFullRateLog(String pid) async {
-    final currentState = state.valueOrNull;
+    final currentState = state.asData?.value;
     if (currentState == null) return;
 
     final fullRateLog = await _rateLogService.fetchFullRateLog(tid, pid);
@@ -237,3 +196,8 @@ class PostNotifier extends StateNotifier<AsyncValue<PostListState>> {
     }
   }
 }
+
+final postProvider = AsyncNotifierProvider.autoDispose
+    .family<PostNotifier, PostListState, String>(
+  PostNotifier.new,
+);

--- a/lib/providers/reading_history_provider.dart
+++ b/lib/providers/reading_history_provider.dart
@@ -4,7 +4,6 @@ import '../services/reading_history_service.dart';
 import 'auth_provider.dart';
 import 'settings_provider.dart';
 
-/// 依赖登录态获取当前 uid，实现按用户隔离。
 final readingHistoryServiceProvider = Provider<ReadingHistoryService>((ref) {
   final local = ref.watch(localDataProvider);
   final rawUid = ref.watch(authStateProvider).user?.uid;
@@ -12,30 +11,32 @@ final readingHistoryServiceProvider = Provider<ReadingHistoryService>((ref) {
   return ReadingHistoryService(local, uid);
 });
 
-/// 单条帖子的阅读记录（供 ThreadCard / ThreadDetailScreen 使用）。
-final readingRecordProvider = Provider.family<ReadingRecord?, String>((ref, tid) {
+final readingRecordProvider =
+    Provider.family<ReadingRecord?, String>((ref, tid) {
   return ref.watch(readingHistoryServiceProvider).getRecord(tid);
 });
 
-final readingHistoryProvider =
-    StateNotifierProvider<ReadingHistoryNotifier, List<ReadingRecord>>((ref) {
-  return ReadingHistoryNotifier(ref.watch(readingHistoryServiceProvider));
-});
+class ReadingHistoryNotifier extends Notifier<List<ReadingRecord>> {
+  @override
+  List<ReadingRecord> build() {
+    return ref.watch(readingHistoryServiceProvider).getAllRecords();
+  }
 
-class ReadingHistoryNotifier extends StateNotifier<List<ReadingRecord>> {
-  ReadingHistoryNotifier(this._service) : super(_service.getAllRecords());
-
-  final ReadingHistoryService _service;
-
-  void refresh() => state = _service.getAllRecords();
+  void refresh() =>
+      state = ref.read(readingHistoryServiceProvider).getAllRecords();
 
   void delete(String tid) {
-    _service.deleteRecord(tid);
-    state = _service.getAllRecords();
+    ref.read(readingHistoryServiceProvider).deleteRecord(tid);
+    state = ref.read(readingHistoryServiceProvider).getAllRecords();
   }
 
   Future<void> clearAll() async {
-    await _service.clearAll();
+    await ref.read(readingHistoryServiceProvider).clearAll();
     state = [];
   }
 }
+
+final readingHistoryProvider =
+    NotifierProvider<ReadingHistoryNotifier, List<ReadingRecord>>(
+  ReadingHistoryNotifier.new,
+);

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -59,50 +59,72 @@ final settingsStoreProvider = Provider<SettingsStore>((ref) {
   return ref.watch(localDataProvider).settings;
 });
 
-class SettingsNotifier extends StateNotifier<AppSettings> {
-  SettingsNotifier({SettingsStore? store, AppSettings? initial})
-      : _store = store,
-        super(initial ?? const AppSettings()) {
-    if (initial == null) {
-      _loadSettings();
+class SettingsNotifier extends Notifier<AppSettings> {
+  SettingsNotifier({this.initial, this.store});
+
+  final AppSettings? initial;
+  final SettingsStore? store;
+
+  @override
+  AppSettings build() {
+    if (initial != null) return initial!;
+    return _loadSettings();
+  }
+
+  SettingsStore? get _effectiveStore {
+    if (store != null) return store;
+    try {
+      return ref.read(settingsStoreProvider);
+    } catch (_) {
+      return null;
     }
   }
 
-  final SettingsStore? _store;
+  void _persist(String key, Object? value) => _effectiveStore?.put(key, value);
 
-  void _persist(String key, Object? value) => _store?.put(key, value);
+  AppSettings _loadSettings() {
+    final settingsStore = _effectiveStore;
+    if (settingsStore == null) return const AppSettings();
 
-  void _loadSettings() {
-    final store = _store;
-    if (store == null) return;
-
-    String themeMode = store.get<String>('themeMode', defaultValue: '') ?? '';
+    String themeMode =
+        settingsStore.get<String>('themeMode', defaultValue: '') ?? '';
     if (themeMode.isEmpty) {
       final oldDarkMode =
-          store.get<bool>('darkMode', defaultValue: false) ?? false;
+          settingsStore.get<bool>('darkMode', defaultValue: false) ?? false;
       themeMode = oldDarkMode ? 'dark' : 'system';
-      store.put('themeMode', themeMode);
+      settingsStore.put('themeMode', themeMode);
     }
 
-    state = AppSettings(
+    return AppSettings(
       themeMode: themeMode,
-      themeColor:
-          store.get<String>('themeColor', defaultValue: 'purple') ?? 'purple',
-      showImages: store.get<bool>('showImages', defaultValue: true) ?? true,
-      recordReadingHistory:
-          store.get<bool>('recordReadingHistory', defaultValue: true) ?? true,
-      fontSize: store.get<int>(
+      themeColor: settingsStore.get<String>('themeColor', defaultValue: 'purple') ??
+          'purple',
+      showImages:
+          settingsStore.get<bool>('showImages', defaultValue: true) ?? true,
+      recordReadingHistory: settingsStore.get<bool>(
+            'recordReadingHistory',
+            defaultValue: true,
+          ) ??
+          true,
+      fontSize: settingsStore.get<int>(
             'fontSize',
             defaultValue: S1Typography.defaultBodySize,
           ) ??
           S1Typography.defaultBodySize,
-      useDynamicColor:
-          store.get<bool>('useDynamicColor', defaultValue: false) ?? false,
+      useDynamicColor: settingsStore.get<bool>(
+            'useDynamicColor',
+            defaultValue: false,
+          ) ??
+          false,
       collapsedForums: Set<String>.from(
-        (store.get<List<dynamic>>('collapsedForums'))?.cast<String>() ?? [],
+        (settingsStore.get<List<dynamic>>('collapsedForums'))?.cast<String>() ??
+            [],
       ),
-      simulateDynamic:
-          store.get<bool>('simulateDynamic', defaultValue: false) ?? false,
+      simulateDynamic: settingsStore.get<bool>(
+            'simulateDynamic',
+            defaultValue: false,
+          ) ??
+          false,
     );
   }
 
@@ -174,8 +196,14 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 }
 
 final settingsProvider =
-    StateNotifierProvider<SettingsNotifier, AppSettings>((ref) {
-  return SettingsNotifier(store: ref.watch(settingsStoreProvider));
-});
+    NotifierProvider<SettingsNotifier, AppSettings>(SettingsNotifier.new);
 
-final dynamicColorAvailableProvider = StateProvider<bool>((ref) => false);
+class DynamicColorAvailable extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void setAvailable(bool value) => state = value;
+}
+
+final dynamicColorAvailableProvider =
+    NotifierProvider<DynamicColorAvailable, bool>(DynamicColorAvailable.new);

--- a/lib/providers/thread_list_provider.dart
+++ b/lib/providers/thread_list_provider.dart
@@ -4,12 +4,12 @@ import '../services/api_service.dart';
 import '../services/http_client.dart';
 
 class ThreadListState {
-
   ThreadListState({
     this.threads = const [],
     this.currentPage = 1,
     this.totalPages = 1,
   });
+
   final List<Thread> threads;
   final int currentPage;
   final int totalPages;
@@ -27,52 +27,36 @@ class ThreadListState {
   }
 }
 
-final threadListProvider = StateNotifierProvider.autoDispose.family<
-    ThreadListNotifier, AsyncValue<ThreadListState>, String>(
-  (ref, fid) => ThreadListNotifier(
-    fid: fid,
-    apiService: ApiService(ref.watch(httpClientProvider)),
-  ),
-);
+class ThreadListNotifier extends AsyncNotifier<ThreadListState> {
+  ThreadListNotifier(this.fid);
 
-class ThreadListNotifier extends StateNotifier<AsyncValue<ThreadListState>> {
-
-  ThreadListNotifier({
-    required this.fid,
-    required ApiService apiService,
-  })  : _apiService = apiService,
-        super(const AsyncValue.loading()) {
-    _initLoad();
-  }
   final String fid;
-  final ApiService _apiService;
 
-  Future<void> _initLoad() async {
-    try {
-      final result = await _apiService.getThreadListRaw(fid, page: 1);
-      final threads = ApiService.parseThreadList(result);
-      final totalPages = _extractTotalPages(result);
-      state = AsyncValue.data(ThreadListState(
-        threads: threads,
-        currentPage: 1,
-        totalPages: totalPages,
-      ),);
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
+  @override
+  Future<ThreadListState> build() => _loadPage(1);
+
+  ApiService get _apiService => ApiService(ref.watch(httpClientProvider));
+
+  Future<ThreadListState> _loadPage(int page) async {
+    final result = await _apiService.getThreadListRaw(fid, page: page);
+    final threads = ApiService.parseThreadList(result);
+    final totalPages = _extractTotalPages(result);
+    return ThreadListState(
+      threads: threads,
+      currentPage: page,
+      totalPages: totalPages,
+    );
   }
 
   int _extractTotalPages(Map<String, dynamic> json) {
     final variables = json['Variables'] as Map<String, dynamic>?;
     if (variables == null) return 1;
 
-    // 帖子总数：优先从 Variables.forum.threads 取（Discuz! 标准结构）
     final forum = variables['forum'] as Map<String, dynamic>?;
     int? totalThreads;
     if (forum != null) {
       totalThreads = int.tryParse(forum['threads']?.toString() ?? '');
     }
-    // 兜底：Variables.threadcount 或 Variables.threads
     totalThreads ??= int.tryParse(
       (variables['threadcount'] ?? variables['threads'])?.toString() ?? '',
     );
@@ -84,26 +68,20 @@ class ThreadListNotifier extends StateNotifier<AsyncValue<ThreadListState>> {
   }
 
   Future<void> goToPage(int page) async {
-    final current = state.valueOrNull;
-    try {
-      final result = await _apiService.getThreadListRaw(fid, page: page);
-      final threads = ApiService.parseThreadList(result);
-      final totalPages = _extractTotalPages(result);
-      state = AsyncValue.data(ThreadListState(
-        threads: threads,
-        currentPage: page,
-        totalPages: totalPages,
-      ),);
-    } catch (_) {
-      // 翻页失败时保留当前数据
-      if (current != null) {
-        state = AsyncValue.data(current);
-      }
+    final current = state.asData?.value;
+    state = await AsyncValue.guard(() => _loadPage(page));
+    if (state.hasError && current != null) {
+      state = AsyncValue.data(current);
     }
   }
 
   Future<void> refresh() async {
     state = const AsyncValue.loading();
-    await _initLoad();
+    state = await AsyncValue.guard(() => _loadPage(1));
   }
 }
+
+final threadListProvider = AsyncNotifierProvider.autoDispose
+    .family<ThreadListNotifier, ThreadListState, String>(
+  ThreadListNotifier.new,
+);

--- a/lib/providers/user_space_provider.dart
+++ b/lib/providers/user_space_provider.dart
@@ -13,6 +13,7 @@ class UserSpaceState {
     this.threadTotalPages = 1,
     this.replyTotalPages = 1,
   });
+
   final List<UserSpaceItem> threads;
   final List<UserSpaceItem> replies;
   final int threadPage;
@@ -39,93 +40,91 @@ class UserSpaceState {
   }
 }
 
-final userSpaceProvider = StateNotifierProvider.autoDispose.family<
-    UserSpaceNotifier, AsyncValue<UserSpaceState>, (String, bool)>(
-  (ref, params) => UserSpaceNotifier(
-    uid: params.$1,
-    apiService: ApiService(ref.watch(httpClientProvider)),
-    isSelf: params.$2,
-  ),
-);
+typedef UserSpaceParams = (String uid, bool isSelf);
 
-class UserSpaceNotifier extends StateNotifier<AsyncValue<UserSpaceState>> {
-  UserSpaceNotifier({
-    required this.uid,
-    required ApiService apiService,
-    required this.isSelf,
-  })  : _apiService = apiService,
-        super(const AsyncValue.loading()) {
-    _loadAll();
-  }
-  final String uid;
-  final bool isSelf;
-  final ApiService _apiService;
+class UserSpaceNotifier extends AsyncNotifier<UserSpaceState> {
+  UserSpaceNotifier(this.params);
 
-  Future<void> _loadAll() async {
-    try {
-      final threadFuture = isSelf
-          ? _apiService.getMySpaceList(type: 'thread', page: 1)
-          : _apiService.getUserSpaceList(uid: uid, type: 'thread', page: 1);
-      final replyFuture = _apiService.getUserSpaceList(uid: uid, type: 'reply', page: 1);
+  final UserSpaceParams params;
 
-      final results = await Future.wait<UserSpaceListResult>([
-        threadFuture,
-        replyFuture,
-      ]);
-      final threads = results[0];
-      final replies = results[1];
+  String get uid => params.$1;
+  bool get isSelf => params.$2;
 
-      state = AsyncValue.data(
-        UserSpaceState(
-          threads: threads.items,
-          threadTotalPages: threads.totalPages,
-          replies: replies.items,
-          replyTotalPages: replies.totalPages,
-        ),
-      );
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
+  @override
+  Future<UserSpaceState> build() => _loadAll();
+
+  ApiService get _apiService => ApiService(ref.watch(httpClientProvider));
+
+  Future<UserSpaceState> _loadAll() async {
+    final threadFuture = isSelf
+        ? _apiService.getMySpaceList(type: 'thread', page: 1)
+        : _apiService.getUserSpaceList(uid: uid, type: 'thread', page: 1);
+    final replyFuture =
+        _apiService.getUserSpaceList(uid: uid, type: 'reply', page: 1);
+
+    final results = await Future.wait<UserSpaceListResult>([
+      threadFuture,
+      replyFuture,
+    ]);
+    final threads = results[0];
+    final replies = results[1];
+
+    return UserSpaceState(
+      threads: threads.items,
+      threadTotalPages: threads.totalPages,
+      replies: replies.items,
+      replyTotalPages: replies.totalPages,
+    );
   }
 
   Future<void> goToThreadPage(int page) async {
-    try {
+    state = await AsyncValue.guard(() async {
       final result = isSelf
           ? await _apiService.getMySpaceList(type: 'thread', page: page)
-          : await _apiService.getUserSpaceList(uid: uid, type: 'thread', page: page);
-      final cur = state.valueOrNull ?? UserSpaceState();
-      state = AsyncValue.data(
-        cur.copyWith(
-          threads: result.items,
-          threadPage: page,
-          threadTotalPages: result.totalPages,
-        ),
+          : await _apiService.getUserSpaceList(
+              uid: uid,
+              type: 'thread',
+              page: page,
+            );
+      final cur = state.asData?.value ?? UserSpaceState();
+      return cur.copyWith(
+        threads: result.items,
+        threadPage: page,
+        threadTotalPages: result.totalPages,
       );
-    } catch (e, st) {
-      talker.handle(e, st, 'Load user thread page failed');
-      state = AsyncValue.error(e, st);
-    }
+    });
   }
 
   Future<void> goToReplyPage(int page) async {
-    try {
-      final result = await _apiService.getUserSpaceList(uid: uid, type: 'reply', page: page);
-      final cur = state.valueOrNull ?? UserSpaceState();
-      state = AsyncValue.data(
-        cur.copyWith(
-          replies: result.items,
-          replyPage: page,
-          replyTotalPages: result.totalPages,
-        ),
+    state = await AsyncValue.guard(() async {
+      final result = await _apiService.getUserSpaceList(
+        uid: uid,
+        type: 'reply',
+        page: page,
       );
-    } catch (e, st) {
-      talker.handle(e, st, 'Load user reply page failed');
-      state = AsyncValue.error(e, st);
+      final cur = state.asData?.value ?? UserSpaceState();
+      return cur.copyWith(
+        replies: result.items,
+        replyPage: page,
+        replyTotalPages: result.totalPages,
+      );
+    });
+    if (state.hasError) {
+      final error = state.error;
+      final stack = state.stackTrace;
+      if (error != null && stack != null) {
+        talker.handle(error, stack, 'Load user reply page failed');
+      }
     }
   }
 
   Future<void> refresh() async {
     state = const AsyncValue.loading();
-    await _loadAll();
+    state = await AsyncValue.guard(_loadAll);
   }
 }
+
+final userSpaceProvider = AsyncNotifierProvider.autoDispose
+    .family<UserSpaceNotifier, UserSpaceState, UserSpaceParams>(
+  UserSpaceNotifier.new,
+);

--- a/lib/screens/forum_list_screen.dart
+++ b/lib/screens/forum_list_screen.dart
@@ -32,7 +32,7 @@ class _ForumListScreenState extends ConsumerState<ForumListScreen> {
   }
 
   String _forumName() {
-    final categories = ref.watch(forumListProvider).valueOrNull;
+    final categories = ref.watch(forumListProvider).asData?.value;
     if (categories == null) return '';
     for (final cat in categories) {
       if (cat.fid == widget.fid) return cat.name;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -112,7 +112,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         selectedIndex: tabIndex,
         onDestinationSelected: (index) {
           if (_currentTab == 2 && index != 2) {
-            ref.read(messagesSegmentProvider.notifier).state = 0;
+            ref.read(messagesSegmentProvider.notifier).select(0);
           }
           setState(() => _currentTab = index);
         },

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -40,7 +40,7 @@ class _MessagesScreenState extends ConsumerState<MessagesScreen> {
             onSelectionChanged: (value) {
               final next = value.first;
               setState(() => _segment = next);
-              ref.read(messagesSegmentProvider.notifier).state = next;
+              ref.read(messagesSegmentProvider.notifier).select(next);
             },
             style: S1SegmentedButtonStyle.forScheme(scheme),
           ),

--- a/lib/screens/reading_history_screen.dart
+++ b/lib/screens/reading_history_screen.dart
@@ -91,7 +91,7 @@ class _HistoryTile extends ConsumerWidget {
   final ReadingRecord record;
 
   String? _forumName(WidgetRef ref) {
-    final categories = ref.watch(forumListProvider).valueOrNull;
+    final categories = ref.watch(forumListProvider).asData?.value;
     if (categories == null || record.fid.isEmpty) return null;
     for (final category in categories) {
       if (category.fid == record.fid) return category.name;

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -92,7 +92,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         );
     _hasRecordedInitialVisit = true;
     ref.invalidate(readingRecordProvider(widget.tid));
-    // 刷新列表 StateNotifier：ThreadCard 进度条 / 历史页 / 资料计数据此实时更新。
+    // 刷新列表 Notifier：ThreadCard 进度条 / 历史页 / 资料计数据此实时更新。
     ref.read(readingHistoryProvider.notifier).refresh();
   }
 

--- a/lib/services/http_client.dart
+++ b/lib/services/http_client.dart
@@ -4,6 +4,7 @@ import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show ProviderListenable;
 import 'package:path_provider/path_provider.dart';
 import '../config/api_config.dart';
 import '../config/constants.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "12.1.0"
   ansicolor:
     dependency: transitive
     description:
@@ -121,14 +121,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      sha256: "5909d2c6b66817222779e1eedc19e0e28b76d1df7bd9856a4792ccb9881df358"
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -169,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.9"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.1"
   cross_file:
     dependency: transitive
     description:
@@ -205,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.1.8"
   dio:
     dependency: "direct main"
     description:
@@ -245,10 +261,10 @@ packages:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "0994276f63a394b7434ed7deaeffd2ddc855a5eafccf5ed00e5e341905a6f62b"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.3"
+    version: "2.34.0"
   drift_flutter:
     dependency: "direct main"
     description:
@@ -330,10 +346,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.3.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -392,6 +408,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   gal:
     dependency: "direct main"
     description:
@@ -600,6 +624,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.2"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   objective_c:
     dependency: transitive
     description:
@@ -748,10 +780,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.3.2"
   share_plus:
     dependency: transitive
     description:
@@ -776,6 +808,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -797,6 +845,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.3"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -833,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.45.0"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:
@@ -917,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
@@ -925,6 +997,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -1061,6 +1141,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.5.0
+  flutter_riverpod: ^3.3.2
   dio: ^5.4.0
   dio_cookie_manager: ^3.1.1
   cookie_jar: ^4.0.8

--- a/test/helpers/messages_test_helpers.dart
+++ b/test/helpers/messages_test_helpers.dart
@@ -1,14 +1,8 @@
-import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:s1_app/models/notice_item.dart';
 import 'package:s1_app/models/private_message_item.dart';
 import 'package:s1_app/providers/notice_list_provider.dart';
 import 'package:s1_app/providers/pm_list_provider.dart';
-import 'package:s1_app/services/api_service.dart';
-import 'package:s1_app/services/http_client.dart';
-
-ApiService _testApiService() =>
-    ApiService(S1HttpClient.test(ProviderContainer(), Dio()));
 
 PmListState samplePmListState() {
   return PmListState(
@@ -49,22 +43,15 @@ NoticeListState sampleNoticeListState({
 }
 
 List<Override> messagesProviderOverrides({
-  AsyncValue<PmListState>? pmAsync,
-  AsyncValue<NoticeListState>? noticeAsync,
+  PmListState? pmState,
+  NoticeListState? noticeState,
 }) {
   return [
     pmListProvider.overrideWith(
-      (ref) => PmListNotifier(
-        apiService: _testApiService(),
-        initialState: pmAsync ?? AsyncValue.data(samplePmListState()),
-      ),
+      () => PmListNotifier(seed: pmState ?? samplePmListState()),
     ),
     noticeListProvider.overrideWith(
-      (ref) => NoticeListNotifier(
-        apiService: _testApiService(),
-        initialState:
-            noticeAsync ?? AsyncValue.data(sampleNoticeListState()),
-      ),
+      () => NoticeListNotifier(seed: noticeState ?? sampleNoticeListState()),
     ),
   ];
 }

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/providers/settings_provider.dart';
 import 'package:s1_app/services/settings_store.dart';
@@ -20,36 +21,51 @@ void main() {
 
   test('resetAppearanceSettings restores defaults only for appearance prefs',
       () {
-    final notifier = SettingsNotifier(
-      store: store,
-      initial: const AppSettings(
-        themeMode: 'dark',
-        themeColor: 'green',
-        showImages: false,
-        recordReadingHistory: false,
-        fontSize: 18,
-        useDynamicColor: true,
-        collapsedForums: {'42'},
-      ),
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(
+            store: store,
+            initial: const AppSettings(
+              themeMode: 'dark',
+              themeColor: 'green',
+              showImages: false,
+              recordReadingHistory: false,
+              fontSize: 18,
+              useDynamicColor: true,
+              collapsedForums: {'42'},
+            ),
+          ),
+        ),
+      ],
     );
+    addTearDown(container.dispose);
 
-    notifier.resetAppearanceSettings();
+    container.read(settingsProvider.notifier).resetAppearanceSettings();
+    final state = container.read(settingsProvider);
 
-    expect(notifier.state.themeMode, 'system');
-    expect(notifier.state.themeColor, 'purple');
-    expect(notifier.state.showImages, isTrue);
-    expect(notifier.state.recordReadingHistory, isTrue);
-    expect(notifier.state.fontSize, S1Typography.defaultBodySize);
-    expect(notifier.state.useDynamicColor, isFalse);
-    expect(notifier.state.collapsedForums, const {'42'});
+    expect(state.themeMode, 'system');
+    expect(state.themeColor, 'purple');
+    expect(state.showImages, isTrue);
+    expect(state.recordReadingHistory, isTrue);
+    expect(state.fontSize, S1Typography.defaultBodySize);
+    expect(state.useDynamicColor, isFalse);
+    expect(state.collapsedForums, const {'42'});
   });
 
   test('setRecordReadingHistory persists to settings store', () async {
-    final notifier = SettingsNotifier(store: store, initial: const AppSettings());
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(store: store, initial: const AppSettings()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
 
-    notifier.setRecordReadingHistory(false);
+    container.read(settingsProvider.notifier).setRecordReadingHistory(false);
 
-    expect(notifier.state.recordReadingHistory, isFalse);
+    expect(container.read(settingsProvider).recordReadingHistory, isFalse);
     await Future<void>.delayed(const Duration(milliseconds: 50));
     expect(store.get<bool>('recordReadingHistory'), isFalse);
   });

--- a/test/screens/compose_screen_test.dart
+++ b/test/screens/compose_screen_test.dart
@@ -67,6 +67,9 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
+        ],
         child: MaterialApp.router(
           theme: AppTheme.lightTheme('purple'),
           routerConfig: router,
@@ -98,8 +101,11 @@ void main() {
 }
 
 class _LoggedInAuthNotifier extends AuthNotifier {
-  _LoggedInAuthNotifier(Ref ref)
-      : super(ref.watch(authServiceProvider), ref) {
-    state = AuthState(isLoggedIn: true, username: 'tester');
-  }
+  @override
+  AuthState build() => AuthState(isLoggedIn: true, username: 'tester');
+}
+
+class _LoggedOutAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
 }

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -8,7 +8,6 @@ import 'package:s1_app/providers/forum_list_provider.dart';
 import 'package:s1_app/providers/messages_segment_provider.dart';
 import 'package:s1_app/providers/settings_provider.dart';
 import 'package:s1_app/screens/home_screen.dart';
-import 'package:s1_app/services/auth_service.dart';
 import 'package:s1_app/theme/app_theme.dart';
 import '../helpers/messages_test_helpers.dart';
 
@@ -20,7 +19,7 @@ void main() {
           authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
           forumListProvider.overrideWith(_GuestForumListNotifier.new),
           settingsProvider.overrideWith(
-            (ref) => SettingsNotifier(initial: const AppSettings()),
+            () => SettingsNotifier(initial: const AppSettings()),
           ),
           ...messagesProviderOverrides(),
         ],
@@ -48,7 +47,7 @@ void main() {
           authStateProvider.overrideWith(_LoggedInAuthNotifier.new),
           forumListProvider.overrideWith(_GuestForumListNotifier.new),
           settingsProvider.overrideWith(
-            (ref) => SettingsNotifier(initial: const AppSettings()),
+            () => SettingsNotifier(initial: const AppSettings()),
           ),
           ...messagesProviderOverrides(),
         ],
@@ -111,46 +110,18 @@ class _GuestForumListNotifier extends ForumListNotifier {
 }
 
 class _LoggedOutAuthNotifier extends AuthNotifier {
-  _LoggedOutAuthNotifier(Ref ref) : super(_FakeAuthService(), ref) {
-    state = AuthState();
-  }
+  @override
+  AuthState build() => AuthState();
 }
 
 class _LoggedInAuthNotifier extends AuthNotifier {
-  _LoggedInAuthNotifier(Ref ref) : super(_FakeAuthService(), ref) {
-    state = AuthState(
-      isLoggedIn: true,
-      user: User(
-        uid: '1',
-        username: 'tester',
-        avatar: '',
-      ),
-    );
-  }
-}
-
-class _FakeAuthService implements AuthService {
   @override
-  User? get currentUser => null;
-
-  @override
-  bool get isLoggedIn => false;
-
-  @override
-  void setLoggedIn(String username) {}
-
-  @override
-  Future<String?> login(String username, String password) async => null;
-
-  @override
-  Future<User?> fetchProfile() async => null;
-
-  @override
-  Future<void> logout() async {}
-
-  @override
-  Future<bool> checkSession() async => false;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  AuthState build() => AuthState(
+        isLoggedIn: true,
+        user: User(
+          uid: '1',
+          username: 'tester',
+          avatar: '',
+        ),
+      );
 }

--- a/test/screens/profile_screen_test.dart
+++ b/test/screens/profile_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:s1_app/theme/app_theme.dart';
@@ -9,7 +10,6 @@ import 'package:s1_app/providers/auth_provider.dart';
 import 'package:s1_app/providers/settings_provider.dart';
 import 'package:s1_app/services/app_database.dart';
 import 'package:s1_app/services/app_local_data.dart';
-import 'package:s1_app/services/auth_service.dart';
 import 'package:s1_app/models/user.dart';
 import 'package:s1_app/screens/profile_screen.dart';
 
@@ -31,12 +31,21 @@ void main() {
   List<Override> localOverrides() => [
         localDataProvider.overrideWithValue(local),
         settingsProvider.overrideWith(
-          (ref) => SettingsNotifier(
+          () => SettingsNotifier(
             store: local.settings,
             initial: const AppSettings(),
           ),
         ),
       ];
+
+  Override packageInfoOverride() => packageInfoProvider.overrideWith(
+        (_) async => PackageInfo(
+          appName: 'S1',
+          packageName: 'com.example.s1',
+          version: '1.0.0',
+          buildNumber: '1',
+        ),
+      );
 
   group('ProfileScreen', () {
     testWidgets('shows settings entry tile', (tester) async {
@@ -44,14 +53,7 @@ void main() {
         ProviderScope(
           overrides: [
             ...localOverrides(),
-            packageInfoProvider.overrideWith(
-              (_) async => PackageInfo(
-                appName: 'S1',
-                packageName: 'com.example.s1',
-                version: '1.0.0',
-                buildNumber: '1',
-              ),
-            ),
+            packageInfoOverride(),
           ],
           child: MaterialApp(
             theme: AppTheme.lightTheme('purple'),
@@ -73,33 +75,24 @@ void main() {
       addTearDown(() => tester.view.resetPhysicalSize());
 
       final testUser = User(uid: '123', username: 'TestUser');
-      final mockService = _FakeAuthService();
       late _TestAuthNotifier mockNotifier;
 
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             ...localOverrides(),
-            authStateProvider.overrideWith((ref) {
+            authStateProvider.overrideWith(() {
               mockNotifier = _TestAuthNotifier(
                 AuthState(
                   isLoggedIn: true,
                   username: 'TestUser',
                   user: testUser,
                 ),
-                mockService,
-                ref,
+                shouldFail: false,
               );
               return mockNotifier;
             }),
-            packageInfoProvider.overrideWith(
-              (_) async => PackageInfo(
-                appName: 'S1',
-                packageName: 'com.example.s1',
-                version: '1.0.0',
-                buildNumber: '1',
-              ),
-            ),
+            packageInfoOverride(),
           ],
           child: MaterialApp(
             theme: AppTheme.lightTheme('purple'),
@@ -134,33 +127,24 @@ void main() {
       addTearDown(() => tester.view.resetPhysicalSize());
 
       final testUser = User(uid: '123', username: 'TestUser');
-      final mockService = _FakeAuthService();
       late _TestAuthNotifier mockNotifier;
 
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             ...localOverrides(),
-            authStateProvider.overrideWith((ref) {
+            authStateProvider.overrideWith(() {
               mockNotifier = _TestAuthNotifier(
                 AuthState(
                   isLoggedIn: true,
                   username: 'TestUser',
                   user: testUser,
                 ),
-                mockService,
-                ref,
+                shouldFail: false,
               );
               return mockNotifier;
             }),
-            packageInfoProvider.overrideWith(
-              (_) async => PackageInfo(
-                appName: 'S1',
-                packageName: 'com.example.s1',
-                version: '1.0.0',
-                buildNumber: '1',
-              ),
-            ),
+            packageInfoOverride(),
           ],
           child: MaterialApp(
             theme: AppTheme.lightTheme('purple'),
@@ -192,33 +176,24 @@ void main() {
       addTearDown(() => tester.view.resetPhysicalSize());
 
       final testUser = User(uid: '123', username: 'TestUser');
-      final mockService = _FakeAuthService(shouldFail: true);
       late _TestAuthNotifier mockNotifier;
 
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
             ...localOverrides(),
-            authStateProvider.overrideWith((ref) {
+            authStateProvider.overrideWith(() {
               mockNotifier = _TestAuthNotifier(
                 AuthState(
                   isLoggedIn: true,
                   username: 'TestUser',
                   user: testUser,
                 ),
-                mockService,
-                ref,
+                shouldFail: true,
               );
               return mockNotifier;
             }),
-            packageInfoProvider.overrideWith(
-              (_) async => PackageInfo(
-                appName: 'S1',
-                packageName: 'com.example.s1',
-                version: '1.0.0',
-                buildNumber: '1',
-              ),
-            ),
+            packageInfoOverride(),
           ],
           child: MaterialApp(
             theme: AppTheme.lightTheme('purple'),
@@ -245,52 +220,22 @@ void main() {
 }
 
 class _TestAuthNotifier extends AuthNotifier {
-  _TestAuthNotifier(this.initial, this.service, Ref ref) : super(service, ref) {
-    state = initial;
-  }
+  _TestAuthNotifier(this.initial, {required this.shouldFail});
 
   final AuthState initial;
-  final _FakeAuthService service;
+  final bool shouldFail;
   bool logoutCalled = false;
+
+  @override
+  AuthState build() => initial;
 
   @override
   Future<void> logout() async {
     logoutCalled = true;
     await Future<void>.delayed(const Duration(milliseconds: 50));
-    if (service.shouldFail) {
+    if (shouldFail) {
       throw Exception('Network Error');
     }
     state = AuthState(isLoggedIn: false);
   }
-}
-
-class _FakeAuthService implements AuthService {
-  _FakeAuthService({this.shouldFail = false});
-  final bool shouldFail;
-
-  @override
-  User? get currentUser => null;
-
-  @override
-  bool get isLoggedIn => false;
-
-  @override
-  void setLoggedIn(String username) {}
-
-  @override
-  Future<String?> login(String username, String password) async => null;
-
-  @override
-  Future<User?> fetchProfile() async => null;
-
-  @override
-  Future<void> logout() async {}
-
-  @override
-  Future<bool> checkSession() {
-    return Future.value(false);
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -13,7 +13,7 @@ void main() {
       ProviderScope(
         overrides: [
           settingsProvider.overrideWith(
-            (ref) => SettingsNotifier(initial: const AppSettings()),
+            () => SettingsNotifier(initial: const AppSettings()),
           ),
           packageInfoProvider.overrideWith(
             (_) async => PackageInfo(

--- a/test/widgets/image_viewer_test.dart
+++ b/test/widgets/image_viewer_test.dart
@@ -12,7 +12,7 @@ void main() {
       ProviderScope(
         overrides: [
           settingsProvider.overrideWith(
-            (ref) => SettingsNotifier(
+            () => SettingsNotifier(
               initial: const AppSettings(showImages: false),
             ),
           ),
@@ -40,7 +40,7 @@ void main() {
       ProviderScope(
         overrides: [
           settingsProvider.overrideWith(
-            (ref) => SettingsNotifier(
+            () => SettingsNotifier(
               initial: const AppSettings(showImages: false),
             ),
           ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

技术栈现代化 **P2**：将 `flutter_riverpod` 升级到 **^3.3.2**，并把全部状态从旧式 API 迁到 `Notifier` / `AsyncNotifier`（不依赖长期 `legacy.dart`）。

基于 `cursor/storage-p1-drift-3d9b`（P1）。

## Changes

- Providers：`Auth` / `Settings` / 列表类 / 消息分段 / 动态色可用性等改为 `Notifier` 或 `AsyncNotifier`
- UI：不再直接写 `notifier.state = …`，改用 `select` / `setAvailable` 等方法
- `valueOrNull` → `asData?.value`
- `http_client`：从 `flutter_riverpod/misc.dart` 引入 `ProviderListenable`
- 测试：`overrideWith(() => …)` / 子类覆盖 `build()` 适配 Riverpod 3

## Verification

- `flutter analyze`：无 error（仅既有 unused 警告）
- `flutter test`：240 passed
- `dart run scripts/audit_m3.dart --fail-on-error`：P0/P1 = 0

## Stack

| PR | Scope |
|---|---|
| #9 P0 | flutter_html + patches |
| #10 P1 | Hive → Drift |
| **this P2** | Riverpod 3 |
| P3+ | image disk cache, backup, go_router 17, AGENTS lock |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

