### PR TITLE
feat(image): P3 图片磁盘缓存与清除入口

### DIFF
--- a/lib/providers/image_cache_provider.dart
+++ b/lib/providers/image_cache_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/s1_image_cache.dart';
+import '../widgets/image_viewer.dart';
+
+/// Approximate image disk-cache size; invalidate after clear.
+final imageCacheSizeProvider = FutureProvider.autoDispose<int>((ref) {
+  return S1ImageCache.approximateSizeBytes();
+});
+
+Future<void> clearS1ImageCaches() {
+  return S1ImageCache.clear(clearMemoryLru: ImageViewer.clearMemoryCache);
+}

--- a/lib/screens/image_viewer_screen.dart
+++ b/lib/screens/image_viewer_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -12,6 +13,7 @@ import 'package:go_router/go_router.dart';
 
 import '../config/resource_domains.dart';
 import '../services/http_client.dart';
+import '../services/s1_image_cache.dart';
 import '../theme/app_theme.dart';
 import '../utils/s1_snack_bar.dart';
 import '../widgets/web_image_stub.dart'
@@ -55,7 +57,15 @@ class _ImageViewerScreenState extends ConsumerState<ImageViewerScreen> {
 
   ImageProvider _resolveProvider() {
     final bytes = widget.imageBytes ?? _fetchedBytes;
-    if (bytes == null) return NetworkImage(widget.imageUrl);
+    if (bytes == null) {
+      if (widget.resourceType == ResourceType.publicAsset && !kIsWeb) {
+        return CachedNetworkImageProvider(
+          widget.imageUrl,
+          cacheManager: S1ImageCache.manager,
+        );
+      }
+      return NetworkImage(widget.imageUrl);
+    }
 
     if (_cachedMemoryImage != null && identical(_cachedMemoryImage!.bytes, bytes)) {
       return _cachedMemoryImage!;
@@ -104,12 +114,17 @@ class _ImageViewerScreenState extends ConsumerState<ImageViewerScreen> {
 
   Future<Uint8List?> _tryFetchBytes() async {
     try {
+      final disk = await S1ImageCache.getBytes(widget.imageUrl);
+      if (disk != null) return disk;
+
       final httpClient = ref.read(httpClientProvider);
       final response = await httpClient.get(
         widget.imageUrl,
         options: Options(responseType: ResponseType.bytes),
       );
-      return Uint8List.fromList(response.data as List<int>);
+      final bytes = Uint8List.fromList(response.data as List<int>);
+      await S1ImageCache.putBytes(widget.imageUrl, bytes);
+      return bytes;
     } catch (_) {
       return null;
     }

--- a/lib/services/s1_image_cache.dart
+++ b/lib/services/s1_image_cache.dart
@@ -1,0 +1,114 @@
+import 'dart:io' show Directory, File;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/painting.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// App-level image disk cache (Native).
+///
+/// Web keeps relying on the browser cache; this manager is still safe to call
+/// for clear/size no-ops / IndexedDB-backed cache_manager behaviour.
+class S1ImageCache {
+  S1ImageCache._();
+
+  static const String cacheKey = 's1ImageCache';
+  static const Duration stalePeriod = Duration(days: 14);
+  static const int maxNrOfCacheObjects = 500;
+
+  static CacheManager? _manager;
+
+  /// Shared [CacheManager] used by CachedNetworkImage / Dio write-through.
+  static CacheManager get manager {
+    return _manager ??= CacheManager(
+      Config(
+        cacheKey,
+        stalePeriod: stalePeriod,
+        maxNrOfCacheObjects: maxNrOfCacheObjects,
+      ),
+    );
+  }
+
+  @visibleForTesting
+  static void debugSetManager(CacheManager? value) {
+    _manager = value;
+  }
+
+  /// Read cached bytes if present (disk). Returns null on miss / Web soft-fail.
+  static Future<Uint8List?> getBytes(String url) async {
+    try {
+      final info = await manager.getFileFromCache(url);
+      if (info == null) return null;
+      return await info.file.readAsBytes();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Persist bytes fetched via Dio (auth / proxied images) into the same store.
+  static Future<void> putBytes(String url, Uint8List bytes) async {
+    try {
+      await manager.putFile(
+        url,
+        bytes,
+        maxAge: stalePeriod,
+        fileExtension: extensionFromUrl(url) ?? 'bin',
+      );
+    } catch (_) {
+      // Disk cache is best-effort; callers still keep memory LRU.
+    }
+  }
+
+  /// Clear disk cache + Flutter image memory pool.
+  ///
+  /// [clearMemoryLru] lets widgets flush their process-local byte maps.
+  static Future<void> clear({void Function()? clearMemoryLru}) async {
+    clearMemoryLru?.call();
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+    try {
+      await manager.emptyCache();
+    } catch (_) {
+      // Ignore platform / store errors; memory pools above are already cleared.
+    }
+  }
+
+  /// Approximate on-disk size in bytes. Web returns 0 (browser-managed).
+  static Future<int> approximateSizeBytes() async {
+    if (kIsWeb) return 0;
+    try {
+      final root = await getTemporaryDirectory();
+      final cacheDir = Directory(p.join(root.path, cacheKey));
+      if (!await cacheDir.exists()) return 0;
+      var total = 0;
+      await for (final entity in cacheDir.list(recursive: true, followLinks: false)) {
+        if (entity is File) {
+          total += await entity.length();
+        }
+      }
+      return total;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  static String formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  @visibleForTesting
+  static String? extensionFromUrl(String url) {
+    final path = Uri.tryParse(url)?.path ?? '';
+    final dot = path.lastIndexOf('.');
+    if (dot < 0 || dot >= path.length - 1) return null;
+    final ext = path.substring(dot + 1).toLowerCase();
+    if (ext.isEmpty || ext.length > 5 || ext.contains('/')) return null;
+    return ext;
+  }
+}

--- a/lib/widgets/image_viewer.dart
+++ b/lib/widgets/image_viewer.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 import 'dart:typed_data';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -8,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import '../config/resource_domains.dart';
 import '../providers/settings_provider.dart';
 import '../services/http_client.dart';
+import '../services/s1_image_cache.dart';
 import '../theme/app_theme.dart';
 import 'web_image_stub.dart'
     if (dart.library.html) 'web_image_html.dart';
@@ -27,12 +29,19 @@ class ImageViewer extends ConsumerStatefulWidget {
   final bool showBorder;
   final EdgeInsetsGeometry? margin;
 
+  /// Flush process-local byte LRU (called when clearing disk cache in settings).
+  static void clearMemoryCache() {
+    _ImageViewerState._cache.clear();
+    _ImageViewerState._providerCache.clear();
+    _ImageViewerState._cacheBytes = 0;
+  }
+
   @override
   ConsumerState<ImageViewer> createState() => _ImageViewerState();
 }
 
 class _ImageViewerState extends ConsumerState<ImageViewer> {
-  /// 图片字节缓存（LRU），独立于 widget 生命周期
+  /// 图片字节缓存（LRU），独立于 widget 生命周期；磁盘层见 [S1ImageCache]
   static final LinkedHashMap<String, Uint8List> _cache = LinkedHashMap();
   static final Map<String, MemoryImage> _providerCache = {};
   static const int _maxCacheEntries = 200;
@@ -86,17 +95,17 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
       return;
     }
 
-    // 公开资源：Web 端用原生 <img>，Native 端用 NetworkImage，都不需要 Dio
+    // 公开资源：Web 端用原生 <img>，Native 端走磁盘缓存 ImageProvider
     if (_resourceType == ResourceType.publicAsset) {
       _loading = false;
       if (kIsWeb) _detectAspectRatio();
       return;
     }
 
-    _loadViaDio();
+    _loadAuthOrProxied();
   }
 
-  void _putInCache(String url, Uint8List data) {
+  void _putInMemoryCache(String url, Uint8List data) {
     if (_cache.containsKey(url)) {
       _cacheBytes -= _cache[url]!.length;
       _cache.remove(url);
@@ -114,13 +123,32 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
     }
   }
 
-  Future<void> _loadViaDio() async {
+  ImageProvider _publicNetworkProvider() {
+    return CachedNetworkImageProvider(
+      widget.imageUrl,
+      cacheManager: S1ImageCache.manager,
+    );
+  }
+
+  Future<void> _loadAuthOrProxied() async {
     if (!mounted) return;
     setState(() {
       _loading = true;
     });
 
     try {
+      final disk = await S1ImageCache.getBytes(widget.imageUrl);
+      if (!mounted) return;
+      if (disk != null) {
+        _putInMemoryCache(widget.imageUrl, disk);
+        setState(() {
+          _bytes = disk;
+          _imageProvider = _providerCache[widget.imageUrl];
+          _loading = false;
+        });
+        return;
+      }
+
       final httpClient = ref.read(httpClientProvider);
       final response = await httpClient.get(
         widget.imageUrl,
@@ -129,9 +157,10 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
       if (!mounted) return;
       final data = response.data as Uint8List;
 
-      // 写入 LRU 缓存
-      _putInCache(widget.imageUrl, data);
+      _putInMemoryCache(widget.imageUrl, data);
+      await S1ImageCache.putBytes(widget.imageUrl, data);
 
+      if (!mounted) return;
       setState(() {
         _bytes = data;
         _imageProvider = _providerCache[widget.imageUrl];
@@ -225,9 +254,9 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
       return _buildImage(_imageProvider!);
     }
 
-    // Native 公开资源：NetworkImage
+    // Native 公开资源：磁盘缓存 ImageProvider
     if (_resourceType == ResourceType.publicAsset) {
-      return _buildImage(NetworkImage(widget.imageUrl));
+      return _buildImage(_publicNetworkProvider());
     }
 
     // 加载中
@@ -321,7 +350,7 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
       button: true,
       label: '重试加载图片',
       child: GestureDetector(
-        onTap: _loadViaDio,
+        onTap: _loadAuthOrProxied,
         child: Container(
           height: 80,
           decoration: BoxDecoration(
@@ -348,7 +377,7 @@ class _ImageViewerState extends ConsumerState<ImageViewer> {
     } else {
       child = Image(
         key: ValueKey(widget.imageUrl),
-        image: _imageProvider ?? NetworkImage(widget.imageUrl),
+        image: _imageProvider ?? _publicNetworkProvider(),
         width: size,
         height: size,
         fit: BoxFit.contain,

--- a/lib/widgets/settings/data_management_section.dart
+++ b/lib/widgets/settings/data_management_section.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/post_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../providers/image_cache_provider.dart';
 import '../../providers/reading_history_provider.dart';
 import '../../providers/settings_provider.dart';
+import '../../services/s1_image_cache.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/s1_snack_bar.dart';
 import 'settings_section_header.dart';
@@ -21,6 +24,7 @@ class DataManagementSection extends ConsumerStatefulWidget {
 class _DataManagementSectionState extends ConsumerState<DataManagementSection> {
   bool _clearingHistory = false;
   bool _clearingVotes = false;
+  bool _clearingImageCache = false;
   bool _resettingSettings = false;
   bool _loggingOut = false;
 
@@ -121,6 +125,26 @@ class _DataManagementSectionState extends ConsumerState<DataManagementSection> {
     );
   }
 
+  Future<void> _clearImageCache() async {
+    await _confirmAction(
+      title: '清除图片缓存',
+      content: kIsWeb
+          ? '将清除应用内图片内存缓存。浏览器磁盘缓存由系统管理，可能无法完全清空。'
+          : '将删除本地下载的图片缓存，下次浏览时会重新下载。',
+      confirmLabel: '清除',
+      isDestructive: true,
+      onConfirm: () => _runTask(
+        current: _clearingImageCache,
+        setBusy: (value) => _clearingImageCache = value,
+        successMessage: '已清除图片缓存',
+        action: () async {
+          await clearS1ImageCaches();
+          ref.invalidate(imageCacheSizeProvider);
+        },
+      ),
+    );
+  }
+
   Future<void> _resetAppearanceSettings() async {
     await _confirmAction(
       title: '重置显示与主题设置',
@@ -160,6 +184,17 @@ class _DataManagementSectionState extends ConsumerState<DataManagementSection> {
     final hasVoteCache =
         authState.isLoggedIn && (authState.user?.uid.isNotEmpty ?? false);
     final scheme = Theme.of(context).colorScheme;
+    final cacheSizeAsync = ref.watch(imageCacheSizeProvider);
+    final cacheSubtitle = cacheSizeAsync.when(
+      data: (bytes) {
+        if (kIsWeb || bytes <= 0) {
+          return '清除已下载的图片，释放本地空间';
+        }
+        return '当前约占用 ${S1ImageCache.formatSize(bytes)}';
+      },
+      loading: () => '清除已下载的图片，释放本地空间',
+      error: (_, __) => '清除已下载的图片，释放本地空间',
+    );
 
     return Card(
       elevation: 0,
@@ -208,6 +243,28 @@ class _DataManagementSectionState extends ConsumerState<DataManagementSection> {
               onTap: !hasVoteCache || _clearingVotes
                   ? null
                   : () => unawaited(_clearPollVotes()),
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+              shape: const RoundedRectangleBorder(
+                borderRadius: S1Shape.small,
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: Icon(
+                Icons.image_not_supported_outlined,
+                color: scheme.onSurfaceVariant,
+              ),
+              title: const Text('清除图片缓存'),
+              subtitle: Text(
+                cacheSubtitle,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+              ),
+              trailing: _buildTrailingSpinner(_clearingImageCache),
+              onTap: _clearingImageCache
+                  ? null
+                  : () => unawaited(_clearImageCache()),
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               shape: const RoundedRectangleBorder(
                 borderRadius: S1Shape.small,

--- a/lib/widgets/web_avatar.dart
+++ b/lib/widgets/web_avatar.dart
@@ -1,11 +1,13 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../config/resource_domains.dart';
+import '../services/s1_image_cache.dart';
 import 'avatar_fallback.dart';
 
 /// 跨平台头像组件
 /// Web: 通过代理加载（avatar 服务器未返回 CORS 头）
-/// Native: 用 Image.network 直加载
+/// Native: 磁盘缓存 [CachedNetworkImage]
 class WebAvatar extends StatelessWidget {
 
   const WebAvatar({
@@ -30,14 +32,24 @@ class WebAvatar extends StatelessWidget {
       return _fallback(context);
     }
     final imageUrl = kIsWeb ? _proxyUrl(url!) : url!;
+    final size = radius * 2;
     return ClipOval(
-      child: Image.network(
-        imageUrl,
-        width: radius * 2,
-        height: radius * 2,
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => _fallback(context),
-      ),
+      child: kIsWeb
+          ? Image.network(
+              imageUrl,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => _fallback(context),
+            )
+          : CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: S1ImageCache.manager,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              errorWidget: (_, __, ___) => _fallback(context),
+            ),
     );
   }
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import flutter_secure_storage_darwin
 import gal
 import package_info_plus
 import share_plus
+import sqflite_darwin
 import url_launcher_macos
 import webview_flutter_wkwebview
 
@@ -19,6 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.6"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -326,6 +350,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: "direct main"
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_html:
     dependency: "direct main"
     description:
@@ -640,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.4.1"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -784,6 +824,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   share_plus:
     dependency: transitive
     description:
@@ -869,6 +917,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.11"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3+1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sqlcipher_flutter_libs:
     dependency: transitive
     description:
@@ -941,6 +1029,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   talker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   drift: ^2.34.1
   drift_flutter: ^0.3.1
   path: ^1.9.1
+  flutter_cache_manager: ^3.4.1
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_test:

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -36,6 +36,7 @@ void main() {
     expect(find.text('文字大小'), findsOneWidget);
     expect(find.text('浏览行为'), findsOneWidget);
     expect(find.text('数据管理'), findsOneWidget);
+    expect(find.text('清除图片缓存'), findsOneWidget);
     expect(find.text('关于'), findsOneWidget);
     expect(find.text('Material You 动态取色'), findsOneWidget);
     expect(find.text('标准'), findsOneWidget);

--- a/test/services/s1_image_cache_test.dart
+++ b/test/services/s1_image_cache_test.dart
@@ -1,0 +1,150 @@
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/services/s1_image_cache.dart';
+import 'package:s1_app/widgets/image_viewer.dart';
+
+/// In-memory [CacheInfoRepository] for unit tests (no path_provider).
+class _MemoryCacheInfoRepository extends CacheInfoRepository {
+  final Map<String, CacheObject> _byKey = {};
+  int _nextId = 1;
+
+  @override
+  Future<CacheObject> insert(
+    CacheObject cacheObject, {
+    bool setTouchedToNow = true,
+  }) async {
+    final stored = cacheObject.copyWith(id: _nextId++);
+    _byKey[stored.key] = stored;
+    return stored;
+  }
+
+  @override
+  Future<CacheObject?> get(String key) async => _byKey[key];
+
+  @override
+  Future<int> delete(int id) async {
+    _byKey.removeWhere((_, obj) => obj.id == id);
+    return 1;
+  }
+
+  @override
+  Future<int> deleteAll(Iterable<int> ids) async {
+    final idSet = ids.toSet();
+    _byKey.removeWhere((_, obj) => idSet.contains(obj.id));
+    return idSet.length;
+  }
+
+  @override
+  Future<List<CacheObject>> getAllObjects() async => _byKey.values.toList();
+
+  @override
+  Future<List<CacheObject>> getObjectsOverCapacity(int capacity) async => [];
+
+  @override
+  Future<List<CacheObject>> getOldObjects(Duration maxAge) async => [];
+
+  @override
+  Future<bool> open() async => true;
+
+  @override
+  Future<bool> close() async => true;
+
+  @override
+  Future<int> update(
+    CacheObject cacheObject, {
+    bool setTouchedToNow = true,
+  }) async {
+    if (cacheObject.id == null) return 0;
+    _byKey[cacheObject.key] = cacheObject;
+    return 1;
+  }
+
+  @override
+  Future updateOrInsert(CacheObject cacheObject) async {
+    if (cacheObject.id == null) {
+      return insert(cacheObject);
+    }
+    return update(cacheObject);
+  }
+
+  @override
+  Future<void> deleteDataFile() async {}
+
+  @override
+  Future<bool> exists() async => true;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    S1ImageCache.debugSetManager(null);
+  });
+
+  group('S1ImageCache.formatSize', () {
+    test('formats bytes / KB / MB', () {
+      expect(S1ImageCache.formatSize(512), '512 B');
+      expect(S1ImageCache.formatSize(2048), '2.0 KB');
+      expect(S1ImageCache.formatSize(3 * 1024 * 1024), '3.0 MB');
+    });
+  });
+
+  group('S1ImageCache.extensionFromUrl', () {
+    test('extracts common extensions', () {
+      expect(
+        S1ImageCache.extensionFromUrl('https://a.example/x/y.jpg'),
+        'jpg',
+      );
+      expect(
+        S1ImageCache.extensionFromUrl('https://a.example/x/y.PNG?q=1'),
+        'png',
+      );
+    });
+
+    test('returns null for missing or odd paths', () {
+      expect(S1ImageCache.extensionFromUrl('https://a.example/x/y'), isNull);
+      expect(
+        S1ImageCache.extensionFromUrl('https://a.example/x/y.toolongext'),
+        isNull,
+      );
+    });
+  });
+
+  group('S1ImageCache put/get/clear', () {
+    test('round-trips bytes through CacheManager and clears', () async {
+      final manager = CacheManager(
+        Config(
+          's1ImageCacheMemoryTest',
+          stalePeriod: const Duration(days: 1),
+          maxNrOfCacheObjects: 20,
+          repo: _MemoryCacheInfoRepository(),
+          fileSystem: MemoryCacheSystem(),
+        ),
+      );
+      addTearDown(() async {
+        await manager.dispose();
+      });
+      S1ImageCache.debugSetManager(manager);
+
+      const url = 'https://example.com/pic.jpg';
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+
+      await S1ImageCache.putBytes(url, bytes);
+      final loaded = await S1ImageCache.getBytes(url);
+      expect(loaded, bytes);
+
+      var cleared = false;
+      await S1ImageCache.clear(clearMemoryLru: () => cleared = true);
+      expect(cleared, isTrue);
+
+      final afterClear = await S1ImageCache.getBytes(url);
+      expect(afterClear, isNull);
+    });
+  });
+
+  test('ImageViewer.clearMemoryCache is safe to call', () {
+    ImageViewer.clearMemoryCache();
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

技术栈现代化 **P3**：Native 图片磁盘缓存 + 设置页「清除图片缓存」。

基于 `cursor/state-p2-riverpod3-3d9b`（P2）。

## Changes

- 新增 `flutter_cache_manager` / `cached_network_image`
- `S1ImageCache`：统一 CacheManager（14 天 / 500 对象）、`putBytes`/`getBytes`、`clear`、占用估算
- `ImageViewer` / `ImageViewerScreen` / `WebAvatar`：Native 公开图走磁盘缓存；需 Cookie 的 Dio 图写回同一缓存；保留内存 LRU
- Web：仍用浏览器/`<img>` 策略；清除时清理内存池并说明限制
- 设置 → 数据管理：「清除图片缓存」+ 可选占用大小

## Verification

- `flutter analyze`：无 error
- `flutter test`：245 passed
- M3 audit：P0/P1 = 0

## Stack

| PR | Scope |
|---|---|
| #9–#11 | P0–P2 |
| **this P3** | image disk cache |
| P4+ | backup L1, go_router 17, AGENTS lock |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

