### PR TITLE
chore(deps): P5 go_router 17 + flutter_lints 6

### DIFF
--- a/lib/config/resource_domains.dart
+++ b/lib/config/resource_domains.dart
@@ -3,7 +3,7 @@
 /// 论坛历史上换过多次资源域名，所有域名规则集中在此文件管理。
 /// Flutter 端（http_client / image_viewer）和代理端（proxy_server）共享此配置。
 /// 新增/修改域名只需改动此文件。
-library resource_domains;
+library;
 
 import 'env_config.dart';
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -253,8 +253,6 @@ class _StatsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     return Card(
       elevation: 0,
       child: Padding(
@@ -435,8 +433,6 @@ class _InfoCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     return Card(
       elevation: 0,
       child: Column(
@@ -497,7 +493,6 @@ abstract class _ProfileListMetrics {
   static const double iconSize = 24;
   static const double gap = 16;
   static const double vPadding = 12;
-  static const double textIndent = hPadding + iconSize + gap;
 }
 
 class _SystemGroupCard extends ConsumerWidget {

--- a/lib/widgets/settings/about_settings_section.dart
+++ b/lib/widgets/settings/about_settings_section.dart
@@ -12,8 +12,6 @@ class AboutSettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-
     return const Card(
       elevation: 0,
       child: Padding(

--- a/lib/widgets/settings/font_size_section.dart
+++ b/lib/widgets/settings/font_size_section.dart
@@ -19,7 +19,6 @@ class FontSizeSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final fontSize = ref.watch(settingsProvider.select((s) => s.fontSize));
     final notifier = ref.read(settingsProvider.notifier);
-    final scheme = Theme.of(context).colorScheme;
 
     return Card(
       elevation: 0,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -442,10 +442,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "6.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.3.0"
   graphs:
     dependency: transitive
     description:
@@ -668,10 +668,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "6.1.0"
   list_counter:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   webview_flutter: ^4.7.0
   # Temporary: one-shot Hive → Drift migration only. Remove after migration window.
   hive: ^2.2.3
-  go_router: ^14.0.0
+  go_router: ^17.0.0
   html: ^0.15.4
   url_launcher: ^6.2.5
   flutter_html: ^3.0.0
@@ -40,7 +40,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
   build_runner: ^2.4.8
   drift_dev: ^2.34.0
   http: ^1.6.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

技术栈现代化 **P5**：`go_router` ^17、`flutter_lints` ^6，并清理新规则下的 lint。

基于 `cursor/backup-p4-l1-3d9b`（P4）。

## Changes

- `go_router: ^17.0.0`（解析到 17.3.0）
- `flutter_lints: ^6.0.0`（`lints` 6.1.0）
- 清理 unused locals / `library;` 匿名库声明

## Verification

- `flutter analyze`：**No issues found**
- `flutter test`：251 passed
- M3 audit：P0/P1 = 0

## Next

P6：更新 `AGENTS.md` 技术栈锁定表与本系列实现对齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ada8aa-7c44-4b7f-a775-f589443b3d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

