### PR TITLE
fix(reading): 已读帖续读落末页，并处理新回复后的页数变化

### DIFF
--- a/lib/models/reading_record.dart
+++ b/lib/models/reading_record.dart
@@ -71,7 +71,41 @@ class ReadingRecord {
   ///
   /// 说明：数据流只知「已加载到第几页」，故按页级判定。0 回复帖
   /// (`totalReplies == 0`) 亦满足 `totalPages == 1 && lastReadPage == 1 ⇒ 已读`。
+  /// 仅反映**上次写入时**的缓存；列表卡片请用 [isFinishedAt] 对照实时页数。
   bool get isFinished => lastReadPage >= totalPages;
+
+  /// 相对实时总页数，是否已读完（用于列表/API 页数更新后的展示）。
+  bool isFinishedAt(int liveTotalPages) =>
+      liveTotalPages > 0 && lastReadPage >= liveTotalPages;
+
+  /// 缓存总页数是否落后于实时值（有新回复撑大页数）。
+  bool hasNewPages(int liveTotalPages) => liveTotalPages > totalPages;
+
+  /// 相对实时总页数的进度（列表卡片进度条用）。
+  double progressAt(int liveTotalPages) => liveTotalPages > 0
+      ? (lastReadPage / liveTotalPages).clamp(0.0, 1.0)
+      : 0.0;
+
+  /// 打开详情时应落地的页码（1-based）。
+  ///
+  /// [liveTotalPages] 须来自列表 `thread.replies` 或详情 API 的实时计算值。
+  int resolveOpenPage(int liveTotalPages) {
+    final pages = liveTotalPages.clamp(1, 9999);
+
+    if (!isFinished && lastReadPage > 1) {
+      return lastReadPage.clamp(1, pages);
+    }
+
+    if (isFinished && hasNewPages(pages)) {
+      return (totalPages + 1).clamp(1, pages);
+    }
+
+    if (isFinished) {
+      return pages;
+    }
+
+    return 1;
+  }
 
   Map<String, dynamic> toJson() => {
         'tid': tid,

--- a/lib/screens/reading_history_screen.dart
+++ b/lib/screens/reading_history_screen.dart
@@ -103,10 +103,11 @@ class _HistoryTile extends ConsumerWidget {
   }
 
   void _open(BuildContext context) {
-    if (!record.isFinished && record.lastReadPage > 1) {
-      context.push('/thread/${record.tid}?page=${record.lastReadPage}');
-    } else {
+    final targetPage = record.resolveOpenPage(record.totalPages);
+    if (targetPage <= 1) {
       context.push('/thread/${record.tid}');
+    } else {
+      context.push('/thread/${record.tid}?page=$targetPage');
     }
   }
 

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -49,7 +49,8 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   String? _scrollOncePid;
   bool _showScrollToTop = false;
   bool _hasRecordedInitialVisit = false;
-  bool _hasCheckedResume = false;
+  bool _hasResolvedInitialPage = false;
+  bool _pendingInitialNavigation = false;
   String? _highlightPid;
 
   @override
@@ -73,6 +74,9 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   /// 记录阅读进度：写库 + 刷新历史列表（使列表卡片/历史页/资料计数实时更新）。
   /// readCount 只在本次进入详情页首帧 +1（isNewVisit 由 _hasRecordedInitialVisit 守卫）。
   void _recordProgress(PostListState state) {
+    if (_pendingInitialNavigation) {
+      return;
+    }
     final settings = ref.read(settingsProvider);
     final auth = ref.read(authStateProvider);
     if (!shouldRecordReadingProgress(settings, auth)) {
@@ -96,29 +100,29 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     ref.read(readingHistoryProvider.notifier).refresh();
   }
 
-  /// 无指定初始页时，若存在未读完的历史记录，提示续读。
-  /// 必须在 [_recordProgress] 写库**之前**读取，否则读到的就是本次刚写入的当前页。
-  void _checkResumeReading(PostListState state) {
-    if (_hasCheckedResume) return;
-    _hasCheckedResume = true;
-    final record = ref.read(readingRecordProvider(widget.tid));
-    if (record == null ||
-        record.isFinished ||
-        record.lastReadPage <= 1 ||
-        record.lastReadPage == state.currentPage) {
+  /// 无指定初始页时，按阅读记录自动落到续读/末页/新回复页。
+  /// 须在 [_recordProgress] 写库**之前**执行，且跳转完成前跳过进度写入。
+  void _resolveInitialPage(PostListState state) {
+    if (_hasResolvedInitialPage) return;
+    if (widget.initialPage != null || widget.targetPid != null) {
+      _hasResolvedInitialPage = true;
       return;
     }
-    final targetPage = record.lastReadPage;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    _hasResolvedInitialPage = true;
+
+    final record = ref.read(readingRecordProvider(widget.tid));
+    if (record == null) return;
+
+    final targetPage = record.resolveOpenPage(state.totalPages);
+    if (targetPage == state.currentPage) return;
+
+    _pendingInitialNavigation = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      S1SnackBar.show(
-        context,
-        message: '上次阅读到第 $targetPage 页',
-        actionLabel: '续读',
-        onAction: () =>
-            ref.read(postProvider(widget.tid).notifier).goToPage(targetPage),
-        duration: const Duration(seconds: 5),
-      );
+      await ref.read(postProvider(widget.tid).notifier).goToPage(targetPage);
+      if (mounted) {
+        setState(() => _pendingInitialNavigation = false);
+      }
     });
   }
 
@@ -281,7 +285,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
       next.whenData((state) {
         // 先按「上一次」记录判断是否提示续读，再写入本次进度。
         if (widget.initialPage == null && widget.targetPid == null) {
-          _checkResumeReading(state);
+          _resolveInitialPage(state);
         }
         _recordProgress(state);
       });

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -29,13 +29,15 @@ class ThreadCard extends ConsumerWidget {
     return (totalPosts / perPage).ceil().clamp(1, 9999);
   }
 
-  /// 点击：有未读完记录则续读到上次页码，否则从第一页打开。
+  /// 点击：按阅读记录解析目标页（续读 / 已读落末页 / 有新回复落新页）。
   void _handleTap(BuildContext context, WidgetRef ref) {
     final record = _recordFor(ref.read(readingHistoryProvider), thread.tid);
-    if (record != null && !record.isFinished && record.lastReadPage > 1) {
-      context.push('/thread/${thread.tid}?page=${record.lastReadPage}');
-    } else {
+    final liveTotalPages = _calcTotalPages(thread.replies);
+    final targetPage = record?.resolveOpenPage(liveTotalPages) ?? 1;
+    if (targetPage <= 1) {
       context.push('/thread/${thread.tid}');
+    } else {
+      context.push('/thread/${thread.tid}?page=$targetPage');
     }
   }
 
@@ -114,7 +116,10 @@ class ThreadCard extends ConsumerWidget {
                     ? () => _showPageSheet(context)
                     : null,
               ),
-              _ReadingProgressBar(tid: thread.tid),
+              _ReadingProgressBar(
+                tid: thread.tid,
+                liveTotalPages: totalPages,
+              ),
             ],
           ),
         ),
@@ -128,8 +133,12 @@ class ThreadCard extends ConsumerWidget {
 // ═══════════════════════════════════════════════════════════
 
 class _ReadingProgressBar extends ConsumerWidget {
-  const _ReadingProgressBar({required this.tid});
+  const _ReadingProgressBar({
+    required this.tid,
+    required this.liveTotalPages,
+  });
   final String tid;
+  final int liveTotalPages;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -137,13 +146,14 @@ class _ReadingProgressBar extends ConsumerWidget {
     final record = ref.watch(
       readingHistoryProvider.select((list) => _recordFor(list, tid)),
     );
-    if (record == null || record.progress <= 0) {
+    if (record == null || record.progressAt(liveTotalPages) <= 0) {
       return const SizedBox.shrink();
     }
 
     final scheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final isFinished = record.isFinished;
+    final isFinished = record.isFinishedAt(liveTotalPages);
+    final hasNewPages = record.hasNewPages(liveTotalPages);
     final accent = isFinished ? scheme.onSurfaceVariant : scheme.primary;
 
     return Padding(
@@ -160,7 +170,7 @@ class _ReadingProgressBar extends ConsumerWidget {
             child: ClipRRect(
               borderRadius: S1Shape.extraSmall,
               child: LinearProgressIndicator(
-                value: record.progress,
+                value: record.progressAt(liveTotalPages),
                 minHeight: 3,
                 backgroundColor: scheme.surfaceContainerHighest,
                 valueColor: AlwaysStoppedAnimation<Color>(
@@ -173,7 +183,11 @@ class _ReadingProgressBar extends ConsumerWidget {
           ),
           const SizedBox(width: 6),
           Text(
-            isFinished ? '已读' : 'P${record.lastReadPage}',
+            isFinished
+                ? '已读'
+                : hasNewPages
+                    ? 'P${record.lastReadPage}/$liveTotalPages'
+                    : 'P${record.lastReadPage}',
             style: textTheme.labelSmall?.copyWith(
               color: accent,
               fontWeight: FontWeight.w500,

--- a/test/models/reading_record_test.dart
+++ b/test/models/reading_record_test.dart
@@ -53,6 +53,39 @@ void main() {
     });
   });
 
+  group('ReadingRecord 相对实时页数', () {
+    test('已读且无新页时 isFinishedAt 为 true', () {
+      final r = _make(lastReadPage: 5, totalPages: 5);
+      expect(r.isFinishedAt(5), isTrue);
+      expect(r.hasNewPages(5), isFalse);
+    });
+
+    test('已读但页数增加后 hasNewPages 为 true', () {
+      final r = _make(lastReadPage: 5, totalPages: 5);
+      expect(r.isFinishedAt(7), isFalse);
+      expect(r.hasNewPages(7), isTrue);
+      expect(r.progressAt(7), closeTo(5 / 7, 0.001));
+    });
+  });
+
+  group('ReadingRecord.resolveOpenPage', () {
+    test('未读完续读到上次页', () {
+      expect(_make(lastReadPage: 3, totalPages: 8).resolveOpenPage(8), 3);
+    });
+
+    test('已读无新回复落最后一页', () {
+      expect(_make(lastReadPage: 5, totalPages: 5).resolveOpenPage(5), 5);
+    });
+
+    test('已读有新回复落原末页下一页', () {
+      expect(_make(lastReadPage: 5, totalPages: 5).resolveOpenPage(7), 6);
+    });
+
+    test('仅读到第一页且未读完仍从第一页打开', () {
+      expect(_make(lastReadPage: 1, totalPages: 4).resolveOpenPage(4), 1);
+    });
+  });
+
   group('ReadingRecord 序列化', () {
     test('toJson/fromJson 往返保持字段', () {
       final r = _make(lastReadPage: 3, totalPages: 5, readCount: 7);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

用户反馈两个阅读进度疑问：

1. 已读完毕后若回复数/页数增加，应如何处理？
2. 已读且无新回复时，再次进入应落最后一页，但此前会从第一页开始。

## 根因

- `ThreadCard` / 阅读历史仅在 `!isFinished && lastReadPage > 1` 时带 `?page=`，**已读帖一律打开第 1 页**。
- 详情页默认加载第 1 页后立刻 `_recordProgress`，会把 `lastReadPage` 写回 1，**污染已读记录**。
- 列表进度条用缓存的 `totalPages` 判定「已读」，**无法感知列表侧 `thread.replies` 增长**。

## 改动

在 `ReadingRecord` 增加页级辅助方法：

- `isFinishedAt(liveTotalPages)` / `hasNewPages(liveTotalPages)` / `progressAt(liveTotalPages)`
- `resolveOpenPage(liveTotalPages)` 统一落地规则：
  - **未读完** → 续读 `lastReadPage`
  - **已读且无新页** → 最后一页
  - **已读但有新页** → 原末页下一页（首屏未读）

接入点：

- `ThreadCard` 点击与进度条（对照列表实时 `replies` 估算页数）
- `ReadingHistoryScreen` 点击（用缓存 `totalPages`，进入详情后由 API 校正）
- `ThreadDetailScreen` 无 `?page=` 时自动跳转，跳转完成前跳过进度写入

## 测试

- 新增 `ReadingRecord.resolveOpenPage` / `hasNewPages` 等单元测试（`test/models/reading_record_test.dart`）
- `flutter analyze` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b577a4b7-9f06-4ed9-bcce-6b1bc585c521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b577a4b7-9f06-4ed9-bcce-6b1bc585c521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

