### PR TITLE
fix(ui): 修复单页主题帖数较少时帖子从底部排列的问题

### DIFF
--- a/lib/widgets/s1_fab_layout.dart
+++ b/lib/widgets/s1_fab_layout.dart
@@ -133,14 +133,12 @@ class S1ContentFabOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       clipBehavior: Clip.none,
-      alignment: Alignment.bottomRight,
+      fit: StackFit.expand,
       children: [
         child,
-        Padding(
-          padding: EdgeInsets.only(
-            right: S1FabLayout.edgeMargin,
-            bottom: fabBottomPadding,
-          ),
+        Positioned(
+          right: S1FabLayout.edgeMargin,
+          bottom: fabBottomPadding,
           child: fab,
         ),
       ],

--- a/test/screens/thread_detail_layout_test.dart
+++ b/test/screens/thread_detail_layout_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/widgets/s1_fab_layout.dart';
+import 'package:s1_app/widgets/s1_swipe_pagination.dart';
+
+void main() {
+  Future<double> topOffset(WidgetTester tester, Finder finder) async {
+    final box = tester.renderObject<RenderBox>(finder);
+    return box.localToGlobal(Offset.zero).dy;
+  }
+
+  Widget buildThreadDetailLikeHarness({
+    required int totalPages,
+    required int currentPage,
+    ValueChanged<ScrollController>? onControllerCreated,
+  }) {
+    return MaterialApp(
+      theme: AppTheme.lightTheme('purple'),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Thread')),
+        body: Column(
+          children: [
+            Expanded(
+              child: S1ContentFabOverlay(
+                fab: S1FabStack(
+                  primary: S1FabItem(
+                    heroTag: 'reply',
+                    icon: Icons.edit,
+                    tooltip: 'reply',
+                    onPressed: () {},
+                  ),
+                ),
+                child: S1SwipePagination(
+                  currentPage: currentPage,
+                  totalPages: totalPages,
+                  onPageChanged: (_) async {},
+                  pageBuilder: (context, scrollController) {
+                    onControllerCreated?.call(scrollController);
+                    return Scrollbar(
+                      controller: scrollController,
+                      child: SingleChildScrollView(
+                        controller: scrollController,
+                        padding: EdgeInsets.only(
+                          bottom: S1FabLayout.contentBottomPadding(
+                            showPrimary: true,
+                          ),
+                        ),
+                        child: const Column(
+                          children: [
+                            _ShortPostCard(label: 'Post 1'),
+                            _ShortPostCard(label: 'Post 2'),
+                            _ShortPostCard(label: 'Post 3'),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(height: 48),
+          ],
+        ),
+      ),
+    );
+  }
+
+  testWidgets('short posts on single-page thread start below app bar', (tester) async {
+    await tester.pumpWidget(buildThreadDetailLikeHarness(
+      totalPages: 1,
+      currentPage: 1,
+    ),);
+    await tester.pumpAndSettle();
+
+    final appBarBottom = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final firstPostTop = await topOffset(tester, find.text('Post 1'));
+    final viewportHeight = tester.getSize(find.byType(Scaffold)).height;
+
+    expect(firstPostTop, greaterThan(appBarBottom - 1));
+    expect(firstPostTop, lessThan(appBarBottom + 40));
+    expect(firstPostTop, lessThan(viewportHeight * 0.35));
+  });
+
+  testWidgets('short posts on multi-page thread page 1 start below app bar', (tester) async {
+    await tester.pumpWidget(buildThreadDetailLikeHarness(
+      totalPages: 5,
+      currentPage: 1,
+    ),);
+    await tester.pumpAndSettle();
+
+    final appBarBottom = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final firstPostTop = await topOffset(tester, find.text('Post 1'));
+
+    expect(firstPostTop, greaterThan(appBarBottom - 1));
+    expect(firstPostTop, lessThan(appBarBottom + 40));
+  });
+
+  testWidgets('stale scroll offset does not pin short posts to bottom', (tester) async {
+    ScrollController? controller;
+
+    await tester.pumpWidget(buildThreadDetailLikeHarness(
+      totalPages: 1,
+      currentPage: 1,
+      onControllerCreated: (c) => controller = c,
+    ),);
+    await tester.pumpAndSettle();
+
+    controller!.jumpTo(400);
+    await tester.pump();
+
+    final scrolledTop = await topOffset(tester, find.text('Post 1'));
+    expect(scrolledTop, lessThan(0));
+
+    await tester.pumpWidget(buildThreadDetailLikeHarness(
+      totalPages: 1,
+      currentPage: 1,
+    ),);
+    await tester.pumpAndSettle();
+
+    final appBarBottom = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final resetTop = await topOffset(tester, find.text('Post 1'));
+    expect(resetTop, greaterThan(appBarBottom - 1));
+    expect(resetTop, lessThan(appBarBottom + 40));
+  });
+}
+
+class _ShortPostCard extends StatelessWidget {
+  const _ShortPostCard({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: SizedBox(
+        height: 80,
+        child: Center(child: Text(label)),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

主题只有一页（`totalPages == 1`）且帖子较少时，帖子列表不从顶部开始排列，而是被推到屏幕下半部分，顶部出现大片空白。

## 根因

`S1ContentFabOverlay` 使用 `Stack(alignment: Alignment.bottomRight)` 叠加 FAB。当子组件（`SingleChildScrollView`）高度小于视口时，Stack 会按 `bottomRight` 对齐子组件，导致短内容贴底显示。

多页主题不受影响，因为 `S1SwipePagination` 会用 `PageView` 包裹内容，子组件始终撑满视口高度。

## 修复

- `S1ContentFabOverlay` 改为 `StackFit.expand`，让内容区始终填满可用空间
- FAB 改用 `Positioned` 固定在右下角，不再影响内容对齐

## 测试

- 新增 `test/screens/thread_detail_layout_test.dart`，覆盖单页/多页主题下短帖列表的顶部对齐
- `flutter analyze` 通过
- `flutter test test/screens/thread_detail_layout_test.dart` 通过

## 影响范围

同时修复帖子详情页与版块列表页（两者均使用 `S1ContentFabOverlay`）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d9a6625-48f4-4f1b-9018-0fa4c9d61ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d9a6625-48f4-4f1b-9018-0fa4c9d61ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

