### PR TITLE
fix(settings): 改进图片缓存占用展示与说明文案

### DIFF
--- a/lib/widgets/settings/browsing_settings_section.dart
+++ b/lib/widgets/settings/browsing_settings_section.dart
@@ -63,7 +63,7 @@ class BrowsingSettingsSection extends ConsumerWidget {
               leading: Icon(Icons.info_outline, color: scheme.onSurfaceVariant),
               title: const Text('图片缓存'),
               subtitle: Text(
-                '当前图片缓存由系统或浏览器管理，应用不提供离线图片缓存清理',
+                '离线图片缓存在「数据管理」中查看占用并清理',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: scheme.onSurfaceVariant,
                     ),

--- a/lib/widgets/settings/data_management_section.dart
+++ b/lib/widgets/settings/data_management_section.dart
@@ -226,12 +226,12 @@ class _DataManagementSectionState extends ConsumerState<DataManagementSection> {
     final cacheSizeAsync = ref.watch(imageCacheSizeProvider);
     final cacheSubtitle = cacheSizeAsync.when(
       data: (bytes) {
-        if (kIsWeb || bytes <= 0) {
-          return '清除已下载的图片，释放本地空间';
+        if (kIsWeb) {
+          return '浏览器管理磁盘缓存；可清除应用内图片内存缓存';
         }
         return '当前约占用 ${S1ImageCache.formatSize(bytes)}';
       },
-      loading: () => '清除已下载的图片，释放本地空间',
+      loading: () => '正在统计缓存占用…',
       error: (_, __) => '清除已下载的图片，释放本地空间',
     );
 

--- a/test/services/s1_image_cache_test.dart
+++ b/test/services/s1_image_cache_test.dart
@@ -85,6 +85,7 @@ void main() {
 
   group('S1ImageCache.formatSize', () {
     test('formats bytes / KB / MB', () {
+      expect(S1ImageCache.formatSize(0), '0 B');
       expect(S1ImageCache.formatSize(512), '512 B');
       expect(S1ImageCache.formatSize(2048), '2.0 KB');
       expect(S1ImageCache.formatSize(3 * 1024 * 1024), '3.0 MB');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

设置页「清除图片缓存」在 Native 端仅有缓存 > 0 时才显示占用大小，空缓存时回退为通用文案，用户难以确认功能是否生效。同时「浏览行为」中的图片缓存说明与「数据管理」实际能力矛盾。

## 抉择

- ✅ **做**：Native 始终显示磁盘占用（含 `0 B`）；修正浏览行为过时说明
- ❌ **不做**：Web 端统计内存 LRU 占用（刷新即失、价值有限，且需暴露 `ImageViewer` 内部状态）

## 变更

- **数据管理 → 清除图片缓存**
  - Native：始终显示「当前约占用 X」（含 `0 B`）
  - Web：说明「浏览器管理磁盘缓存；可清除应用内图片内存缓存」
  - 加载中：显示「正在统计缓存占用…」
- **浏览行为 → 图片缓存**：改为「离线图片缓存在「数据管理」中查看占用并清理」

## 测试

- `flutter analyze`（变更文件）通过
- `flutter test test/services/s1_image_cache_test.dart test/screens/settings_screen_test.dart` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b695604a-07d3-425b-a5e4-efa1153d8fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b695604a-07d3-425b-a5e4-efa1153d8fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

