### PR TITLE
feat(rate): add post rating submit dialog and API

### DIFF
--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -20,6 +20,10 @@ class ApiConfig {
   static String favoriteForumReferer(String fid) =>
       '$forumPostUrl?mod=forumdisplay&fid=$fid&mobile=2';
 
+  /// Discuz 评分 POST 所需的 Referer（来路校验）
+  static String forumRateReferer(String tid, String pid) =>
+      '$forumPostUrl?mod=viewthread&tid=$tid&page=0#pid$pid';
+
   // API module names
   static const String moduleForumIndex = 'forumindex';
   static const String moduleForumDisplay = 'forumdisplay';

--- a/lib/models/rate_form.dart
+++ b/lib/models/rate_form.dart
@@ -1,0 +1,43 @@
+/// S1 论坛评分表单选项（从 Discuz rate 弹窗 HTML 解析）。
+class RateFormOptions {
+  const RateFormOptions({
+    required this.scoreOptions,
+    required this.reasonPresets,
+    this.error,
+  });
+
+  factory RateFormOptions.withDefaults({String? error}) {
+    return RateFormOptions(
+      scoreOptions: defaultScoreOptions,
+      reasonPresets: defaultReasonPresets,
+      error: error,
+    );
+  }
+
+  /// 战斗力预设分值（如 `0`, `+2`, `+1`, `-1`, `-2`）。
+  final List<String> scoreOptions;
+
+  /// 理由预设（首项可为空字符串表示无预设）。
+  final List<String> reasonPresets;
+
+  /// 预取阶段的服务端错误（如自评、无权限）。
+  final String? error;
+
+  bool get hasError => error != null && error!.isNotEmpty;
+
+  /// S1 常见默认预设（解析失败时回退）。
+  static const List<String> defaultScoreOptions = [
+    '0',
+    '+2',
+    '+1',
+    '-1',
+    '-2',
+  ];
+
+  static const List<String> defaultReasonPresets = [
+    '',
+    '好评加鹅',
+    '欢乐多',
+    '思路广',
+  ];
+}

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -15,6 +15,7 @@ import '../models/favorite_item.dart';
 import '../widgets/pagination_bar.dart';
 import '../widgets/post_item.dart';
 import '../widgets/poll_card.dart';
+import '../widgets/rate_dialog.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/s1_fab_layout.dart';
 import '../widgets/s1_swipe_pagination.dart';
@@ -170,6 +171,27 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     await _afterReplySubmitted(result, state);
   }
 
+  bool _canRatePost(Post post) {
+    final auth = ref.read(authStateProvider);
+    if (!auth.isLoggedIn) return false;
+    final currentUid = auth.user?.uid;
+    if (currentUid == null || currentUid.isEmpty) return false;
+    return post.authorId != currentUid;
+  }
+
+  Future<void> _openRateDialog(Post post) async {
+    if (!ref.read(authStateProvider).isLoggedIn) {
+      await context.push('/login');
+      return;
+    }
+    await showRateDialog(
+      context,
+      ref,
+      tid: widget.tid,
+      pid: post.pid,
+    );
+  }
+
   Future<void> _afterReplySubmitted(
     ReplySubmitResult result,
     PostListState state,
@@ -235,6 +257,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
                 displayFloor: displayFloor,
               )
           : null,
+      onRate: _canRatePost(post) ? () => _openRateDialog(post) : null,
     );
   }
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:dio/dio.dart';
+import 'package:html/parser.dart' show parse;
 import '../config/api_config.dart';
 import '../models/thread.dart';
 import '../models/post.dart';
@@ -12,6 +13,7 @@ import '../models/private_message_item.dart';
 import '../models/notice_item.dart';
 import '../models/favorite_item.dart';
 import '../models/message_list_result.dart';
+import '../models/rate_form.dart';
 import '../utils/error_handler.dart';
 import 'formhash_service.dart';
 import 'http_client.dart';
@@ -557,6 +559,175 @@ class ApiService {
     final data = response.data;
     if (data is! String) return '服务器返回异常';
     return parsePollVoteResponse(data);
+  }
+
+  // ── 评分（战斗力）──────────────────────────────────────────
+
+  static String? _extractMessagetextError(String body) {
+    final messagetextMatch = RegExp(
+      r'''id=["']messagetext["'][^>]*>.*?<p>([^<]+)''',
+      dotAll: true,
+    ).firstMatch(body);
+    if (messagetextMatch != null) {
+      final text = messagetextMatch.group(1)?.trim();
+      if (text != null && text.isNotEmpty) return text;
+    }
+
+    final errorhandleMatch = RegExp(
+      r"errorhandle_rate\('([^']*)',\s*'([^']*)'\)",
+    ).firstMatch(body);
+    if (errorhandleMatch != null) {
+      return errorhandleMatch.group(1)?.isNotEmpty == true
+          ? errorhandleMatch.group(1)
+          : errorhandleMatch.group(2);
+    }
+
+    return null;
+  }
+
+  static List<String> _parseSelectOptions(String html, String selectId) {
+    try {
+      final doc = parse(html);
+      final select = doc.querySelector('select#$selectId');
+      if (select == null) return [];
+
+      return select.querySelectorAll('option').map((option) {
+        final value = option.attributes['value'];
+        if (value != null) return value;
+        return option.text.trim();
+      }).where((v) => v.isNotEmpty || selectId == 'reason').toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// 从 Discuz rate 弹窗响应中解析表单选项与错误。
+  static RateFormOptions parseRateFormResponse(String body) {
+    final error = _extractMessagetextError(body);
+    if (error != null) {
+      return RateFormOptions.withDefaults(error: error);
+    }
+
+    var scoreOptions = _parseSelectOptions(body, 'rate1');
+    var reasonPresets = _parseSelectOptions(body, 'reason');
+
+    if (scoreOptions.isEmpty) {
+      scoreOptions = RateFormOptions.defaultScoreOptions;
+    }
+    if (reasonPresets.isEmpty) {
+      reasonPresets = RateFormOptions.defaultReasonPresets;
+    }
+
+    return RateFormOptions(
+      scoreOptions: scoreOptions,
+      reasonPresets: reasonPresets,
+    );
+  }
+
+  /// 预取评分表单（GET）。同时更新 formhash。
+  Future<RateFormOptions> fetchRateForm({
+    required String tid,
+    required String pid,
+  }) async {
+    await _httpClient.ensureFormhash(tid: tid);
+
+    final url = '${ApiConfig.forumPostUrl}'
+        '?mod=misc&action=rate&tid=$tid&pid=$pid&mobile=2&inajax=1';
+
+    try {
+      final response = await _httpClient.get(
+        url,
+        options: Options(responseType: ResponseType.plain),
+      );
+      final body = response.data?.toString() ?? '';
+
+      final formhash = FormhashExtractor.fromHtml(body);
+      if (formhash != null) {
+        _httpClient.updateFormhash(formhash);
+      }
+
+      return parseRateFormResponse(body);
+    } catch (e) {
+      if (e is LoginRequiredException) {
+        return RateFormOptions.withDefaults(error: '请先登录');
+      }
+      return RateFormOptions.withDefaults(
+        error: friendlyError(e, '获取评分表单'),
+      );
+    }
+  }
+
+  static String? parseRateSubmitResponse(String body) {
+    if (body.contains('rate_succeed') ||
+        body.contains('评分成功') ||
+        (body.contains('window.location.href') && body.contains('viewthread'))) {
+      return null;
+    }
+
+    final successMatch = RegExp(
+      r"succeedhandle_rate\('([^']*)'",
+    ).firstMatch(body);
+    if (successMatch != null) return null;
+
+    final error = _extractMessagetextError(body);
+    if (error != null) return error;
+
+    final showMessageMatch = RegExp(
+      r"showmessage\('([^']*)'",
+    ).firstMatch(body);
+    if (showMessageMatch != null) {
+      return showMessageMatch.group(1);
+    }
+
+    final alertMatch = RegExp(r"alert\('([^']*)'\)").firstMatch(body);
+    if (alertMatch != null) return alertMatch.group(1);
+
+    if (body.trim().isEmpty) {
+      return '评分请求无响应，请检查是否已登录';
+    }
+
+    return '服务器返回未知响应';
+  }
+
+  /// 提交评分。成功返回 null，失败返回错误信息。
+  Future<String?> submitRate({
+    required String tid,
+    required String pid,
+    required String score1,
+    String reason = '',
+    bool notifyAuthor = false,
+  }) async {
+    const url = '${ApiConfig.forumPostUrl}'
+        '?mod=misc&action=rate&ratesubmit=yes&infloat=yes&inajax=1';
+
+    final data = <String, String>{
+      'tid': tid,
+      'pid': pid,
+      'referer': ApiConfig.forumRateReferer(tid, pid),
+      'handlekey': 'rate',
+      'score1': score1,
+      'reason': reason,
+      'ratesubmit': 'true',
+    };
+    if (notifyAuthor) {
+      data['sendreasonpm'] = '1';
+    }
+
+    try {
+      final response = await _httpClient.post(
+        url,
+        data: data,
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          responseType: ResponseType.plain,
+        ),
+      );
+      final body = response.data?.toString() ?? '';
+      return parseRateSubmitResponse(body);
+    } catch (e) {
+      if (e is LoginRequiredException) return '请先登录';
+      return friendlyError(e, '评分');
+    }
   }
 
   Future<User?> getUserProfile() async {

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -21,6 +21,7 @@ class PostItem extends ConsumerWidget {
     this.tid,
     this.onFilterByAuthor,
     this.onReply,
+    this.onRate,
     this.rateLog,
     this.isHighlighted = false,
   });
@@ -29,6 +30,7 @@ class PostItem extends ConsumerWidget {
   final String? tid;
   final VoidCallback? onFilterByAuthor;
   final VoidCallback? onReply;
+  final VoidCallback? onRate;
   final PostRateLog? rateLog;
   final bool isHighlighted;
 
@@ -91,6 +93,7 @@ class PostItem extends ConsumerWidget {
                 PostActionMenu(
                   onFilterByAuthor: onFilterByAuthor,
                   onReply: onReply,
+                  onRate: onRate,
                 ),
               ],
             ),

--- a/lib/widgets/rate_dialog.dart
+++ b/lib/widgets/rate_dialog.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/rate_form.dart';
+import '../providers/post_provider.dart';
+import '../utils/s1_snack_bar.dart';
+
+/// 打开评分弹窗：预取表单 → 填写 → 提交 → 刷新评分历史。
+Future<void> showRateDialog(
+  BuildContext context,
+  WidgetRef ref, {
+  required String tid,
+  required String pid,
+}) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) => _RateDialog(tid: tid, pid: pid),
+  );
+}
+
+class _RateDialog extends ConsumerStatefulWidget {
+  const _RateDialog({required this.tid, required this.pid});
+
+  final String tid;
+  final String pid;
+
+  @override
+  ConsumerState<_RateDialog> createState() => _RateDialogState();
+}
+
+class _RateDialogState extends ConsumerState<_RateDialog> {
+  RateFormOptions? _options;
+  String? _loadError;
+
+  late final TextEditingController _reasonController;
+  String _score = '0';
+  bool _notifyAuthor = false;
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _reasonController = TextEditingController();
+    _fetchForm();
+  }
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetchForm() async {
+    final options = await ref.read(apiServiceProvider).fetchRateForm(
+          tid: widget.tid,
+          pid: widget.pid,
+        );
+    if (!mounted) return;
+
+    if (options.hasError) {
+      Navigator.of(context).pop();
+      S1SnackBar.show(context, message: options.error!);
+      return;
+    }
+
+    setState(() {
+      _options = options;
+      _score = options.scoreOptions.first;
+    });
+  }
+
+  Future<void> _submit() async {
+    if (_score == '0') {
+      S1SnackBar.show(context, message: '请选择评分分值');
+      return;
+    }
+
+    setState(() => _submitting = true);
+    try {
+      final error = await ref.read(apiServiceProvider).submitRate(
+            tid: widget.tid,
+            pid: widget.pid,
+            score1: _score,
+            reason: _reasonController.text.trim(),
+            notifyAuthor: _notifyAuthor,
+          );
+      if (!mounted) return;
+
+      if (error != null) {
+        S1SnackBar.show(context, message: error);
+        return;
+      }
+
+      await ref
+          .read(postProvider(widget.tid).notifier)
+          .loadFullRateLog(widget.pid);
+
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      S1SnackBar.show(context, message: '评分成功');
+    } catch (e) {
+      if (!mounted) return;
+      S1SnackBar.show(context, message: '评分失败: $e');
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return AlertDialog(
+      title: Text('评分', style: textTheme.titleLarge),
+      content: _buildContent(context),
+      actions: _options == null
+          ? null
+          : [
+              TextButton(
+                onPressed: _submitting ? null : () => Navigator.of(context).pop(),
+                child: const Text('取消'),
+              ),
+              FilledButton(
+                onPressed: _submitting ? null : _submit,
+                child: _submitting
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('确定'),
+              ),
+            ],
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    if (_loadError != null) {
+      return Text(_loadError!);
+    }
+    if (_options == null) {
+      return const SizedBox(
+        width: 200,
+        height: 80,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final options = _options!;
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return SizedBox(
+      width: double.maxFinite,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _LabeledRow(
+            label: '战斗力',
+            child: DropdownButton<String>(
+              isExpanded: true,
+              value: _score,
+              items: options.scoreOptions
+                  .map(
+                    (score) => DropdownMenuItem(
+                      value: score,
+                      child: Text(score),
+                    ),
+                  )
+                  .toList(),
+              onChanged: _submitting
+                  ? null
+                  : (value) {
+                      if (value != null) setState(() => _score = value);
+                    },
+            ),
+          ),
+          const SizedBox(height: 12),
+          _LabeledRow(
+            label: '理由',
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _reasonController,
+                    enabled: !_submitting,
+                    decoration: const InputDecoration(
+                      hintText: '可选评分理由',
+                      isDense: true,
+                      contentPadding:
+                          EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                DropdownButton<String>(
+                  value: null,
+                  hint: Icon(Icons.arrow_drop_down, color: scheme.onSurfaceVariant),
+                  underline: const SizedBox.shrink(),
+                  items: options.reasonPresets
+                      .map(
+                        (preset) => DropdownMenuItem(
+                          value: preset,
+                          child: Text(preset.isEmpty ? '（无）' : preset),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: _submitting
+                      ? null
+                      : (value) {
+                          if (value != null) {
+                            _reasonController.text = value;
+                          }
+                        },
+                ),
+              ],
+            ),
+          ),
+          CheckboxListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text('通知作者', style: textTheme.bodyMedium),
+            value: _notifyAuthor,
+            onChanged: _submitting
+                ? null
+                : (value) => setState(() => _notifyAuthor = value ?? false),
+            controlAffinity: ListTileControlAffinity.leading,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LabeledRow extends StatelessWidget {
+  const _LabeledRow({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(label, style: textTheme.bodyMedium),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}

--- a/test/services/api_service_test.dart
+++ b/test/services/api_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/rate_form.dart';
 import 'package:s1_app/services/api_service.dart';
 
 void main() {
@@ -287,6 +288,89 @@ void main() {
       test('returns error message on empty body', () {
         expect(
           ApiService.parsePollVoteResponse(''),
+          contains('无响应'),
+        );
+      });
+    });
+
+    group('parseRateFormResponse', () {
+      const formHtml = '''
+<?xml version="1.0" encoding="utf-8"?>
+<root><![CDATA[<form id="rateform">
+<input type="hidden" name="formhash" value="2867b07a" />
+<select id="rate1"><option>0</option><option>+2</option><option>+1</option><option>-1</option><option>-2</option></select>
+<select id="reason"><option value=""></option><option value="好评加鹅">好评加鹅</option><option value="欢乐多">欢乐多</option><option value="思路广">思路广</option></select>
+</form>]]></root>''';
+
+      test('parses score and reason presets from rate form', () {
+        final options = ApiService.parseRateFormResponse(formHtml);
+
+        expect(options.hasError, isFalse);
+        expect(options.scoreOptions, ['0', '+2', '+1', '-1', '-2']);
+        expect(options.reasonPresets, ['', '好评加鹅', '欢乐多', '思路广']);
+      });
+
+      test('returns error for self-rate message', () {
+        const errorHtml = '''
+<root><![CDATA[<div class="tip"><dt id="messagetext">
+<p>抱歉，您不能给自己发表的帖子评分</p>
+</dt></div>]]></root>''';
+
+        final options = ApiService.parseRateFormResponse(errorHtml);
+
+        expect(options.hasError, isTrue);
+        expect(options.error, contains('不能给自己'));
+      });
+
+      test('falls back to defaults on empty body', () {
+        final options = ApiService.parseRateFormResponse('');
+
+        expect(options.hasError, isFalse);
+        expect(options.scoreOptions, RateFormOptions.defaultScoreOptions);
+        expect(options.reasonPresets, RateFormOptions.defaultReasonPresets);
+      });
+    });
+
+    group('parseRateSubmitResponse', () {
+      test('returns null on redirect success XML', () {
+        expect(
+          ApiService.parseRateSubmitResponse(
+            "<?xml version=\"1.0\"?><root><![CDATA[<script>window.location.href='forum.php?mod=viewthread&tid=2285380';</script>]]></root>",
+          ),
+          isNull,
+        );
+      });
+
+      test('returns null on success handler', () {
+        expect(
+          ApiService.parseRateSubmitResponse(
+            "succeedhandle_rate('pid_1', '评分成功');",
+          ),
+          isNull,
+        );
+      });
+
+      test('returns error message on error handler', () {
+        expect(
+          ApiService.parseRateSubmitResponse(
+            "errorhandle_rate('已经评过分了', '');",
+          ),
+          '已经评过分了',
+        );
+      });
+
+      test('returns error message on messagetext', () {
+        expect(
+          ApiService.parseRateSubmitResponse(
+            '<dt id="messagetext"><p>抱歉，您不能给自己发表的帖子评分</p></dt>',
+          ),
+          contains('不能给自己'),
+        );
+      });
+
+      test('returns error message on empty body', () {
+        expect(
+          ApiService.parseRateSubmitResponse(''),
           contains('无响应'),
         );
       });

--- a/test/widgets/post_action_menu_test.dart
+++ b/test/widgets/post_action_menu_test.dart
@@ -60,6 +60,30 @@ void main() {
     expect(replyTapped, isTrue);
   });
 
+  testWidgets('PostActionMenu shows enabled rate when callback provided', (tester) async {
+    var rateTapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme('purple'),
+        home: Scaffold(
+          body: PostActionMenu(
+            onFilterByAuthor: () {},
+            onRate: () => rateTapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('评分'));
+    await tester.pumpAndSettle();
+
+    expect(rateTapped, isTrue);
+  });
+
   testWidgets('PostActionMenu shows disabled labels for unimplemented actions', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements post **评分** (combat power rating) submission for the S1 client:

- **API layer**: `fetchRateForm` (GET `mod=misc&action=rate`) and `submitRate` (POST `ratesubmit=yes`) with Discuz XML/HTML parsers
- **UI**: M3 `AlertDialog` with score dropdown, reason text + presets, and notify-author checkbox
- **Wiring**: `PostActionMenu` → `ThreadDetailScreen` → `showRateDialog`; self-posts and guests are gated client-side
- **Refresh**: On success, `loadFullRateLog(pid)` updates the existing `RateLogCard` display

## Key files

- `lib/models/rate_form.dart` — `RateFormOptions` with S1 default presets fallback
- `lib/services/api_service.dart` — form prefetch, submit, response parsers
- `lib/widgets/rate_dialog.dart` — rating dialog + state machine
- `lib/screens/thread_detail_screen.dart` — login gate + `onRate` callback

## Testing

- `flutter analyze` — 0 issues
- `flutter test` — all tests pass (incl. new `parseRateFormResponse` / `parseRateSubmitResponse` + menu tap test)
- `dart run scripts/audit_m3.dart --fail-on-error` — 0 violations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34eca220-8309-467b-a031-fcbc5d799668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34eca220-8309-467b-a031-fcbc5d799668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

