### PR TITLE
chore(analyze): fix flutter analyze lints

### DIFF
--- a/lib/providers/reading_history_coordinator.dart
+++ b/lib/providers/reading_history_coordinator.dart
@@ -48,6 +48,4 @@ final readingHistoryCoordinatorProvider = Provider<void>((ref) {
       await applyUidChange('guest', uid);
     }
   });
-
-  return null;
 });

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -238,7 +238,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         postKeys: _postKeys,
         onAtLastFloor: () => unawaited(_scrollToBottomImpl()),
       );
-    },));
+    }));
   }
 
   Future<void> _goToPage(int page) async {

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -233,12 +233,14 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
 
   /// 单击「下一楼」：滚至下一楼靠上展示；已是末楼则滚到页底。
   void _scrollToNextFloor() {
-    unawaited(_runScrollAction(() async {
-      await ScrollFloorNavigator.scrollToNextFloor(
-        postKeys: _postKeys,
-        onAtLastFloor: () => unawaited(_scrollToBottomImpl()),
-      );
-    }));
+    unawaited(_runScrollAction(
+      () async {
+        await ScrollFloorNavigator.scrollToNextFloor(
+          postKeys: _postKeys,
+          onAtLastFloor: () => unawaited(_scrollToBottomImpl()),
+        );
+      },
+    ),);
   }
 
   Future<void> _goToPage(int page) async {

--- a/reports/m3_audit_2026-07-13.md
+++ b/reports/m3_audit_2026-07-13.md
@@ -1,6 +1,6 @@
 # M3 Compliance Audit Report
 
-Generated: 2026-07-13T06:20:44.182610Z
+Generated: 2026-07-13T10:12:27.788345Z
 Scanned: lib/ + test/
 
 ## Summary
@@ -9,11 +9,18 @@ Scanned: lib/ + test/
 |----------|-------|
 | P0 | 0 |
 | P1 | 0 |
-| WARN | 1 |
+| WARN | 2 |
 
 ## Findings
 
 ### `test/utils/scroll_floor_test.dart`
+
+- **[WARN] test-missing-apptheme** (L1): Widget test uses MaterialApp without AppTheme / wrapWithAppTheme
+  ```dart
+  MaterialApp(...)
+  ```
+
+### `test/utils/scroll_motion_test.dart`
 
 - **[WARN] test-missing-apptheme** (L1): Widget test uses MaterialApp without AppTheme / wrapWithAppTheme
   ```dart

--- a/test/utils/scroll_floor_test.dart
+++ b/test/utils/scroll_floor_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/utils/scroll_floor.dart';
 
@@ -52,7 +51,7 @@ void main() {
     expect(controller.offset, 0);
     expect(controller.position.maxScrollExtent, greaterThan(0));
 
-    ScrollFloorNavigator.scrollToNextFloor(
+    await ScrollFloorNavigator.scrollToNextFloor(
       postKeys: postKeys,
       onAtLastFloor: () => fail('should not reach last floor'),
     );
@@ -96,7 +95,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.offset, 168);
 
-    ScrollFloorNavigator.scrollToNextFloor(
+    await ScrollFloorNavigator.scrollToNextFloor(
       postKeys: postKeys,
       onAtLastFloor: () => fail('should scroll to post 3'),
     );

--- a/test/utils/scroll_floor_test.dart
+++ b/test/utils/scroll_floor_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/utils/scroll_floor.dart';
@@ -51,9 +53,11 @@ void main() {
     expect(controller.offset, 0);
     expect(controller.position.maxScrollExtent, greaterThan(0));
 
-    await ScrollFloorNavigator.scrollToNextFloor(
-      postKeys: postKeys,
-      onAtLastFloor: () => fail('should not reach last floor'),
+    unawaited(
+      ScrollFloorNavigator.scrollToNextFloor(
+        postKeys: postKeys,
+        onAtLastFloor: () => fail('should not reach last floor'),
+      ),
     );
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpAndSettle();
@@ -95,9 +99,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.offset, 168);
 
-    await ScrollFloorNavigator.scrollToNextFloor(
-      postKeys: postKeys,
-      onAtLastFloor: () => fail('should scroll to post 3'),
+    unawaited(
+      ScrollFloorNavigator.scrollToNextFloor(
+        postKeys: postKeys,
+        onAtLastFloor: () => fail('should scroll to post 3'),
+      ),
     );
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpAndSettle();

--- a/test/widgets/rate_log_card_test.dart
+++ b/test/widgets/rate_log_card_test.dart
@@ -248,7 +248,7 @@ void main() {
 
       await tester.pumpWidget(
         wrap(
-          RateLogCard(tid: '123', pid: '1'),
+          const RateLogCard(tid: '123', pid: '1'),
           tid: '123',
           seed: {'1': rateLog},
         ),

--- a/test/widgets/s1_fab_layout_test.dart
+++ b/test/widgets/s1_fab_layout_test.dart
@@ -9,16 +9,16 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: AppTheme.lightTheme('purple'),
-        home: Scaffold(
+        home: const Scaffold(
           body: S1FabStack(
-            scrollNav: const S1ScrollNavConfig(
+            scrollNav: S1ScrollNavConfig(
               showScrollToTop: true,
               showScrollAdvance: true,
               onScrollToTop: _noop,
               onScrollToNextFloor: _noop,
               onScrollToBottom: _noop,
             ),
-            primary: const S1FabItem(
+            primary: S1FabItem(
               heroTag: 'reply',
               icon: Icons.edit_outlined,
               tooltip: '回复',
@@ -74,9 +74,9 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: AppTheme.lightTheme('purple'),
-        home: Scaffold(
+        home: const Scaffold(
           body: S1ScrollNavGroup(
-            config: const S1ScrollNavConfig(
+            config: S1ScrollNavConfig(
               showScrollToTop: true,
               showScrollAdvance: false,
               onScrollToTop: _noop,
@@ -91,7 +91,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: AppTheme.lightTheme('purple'),
-        home: Scaffold(
+        home: const Scaffold(
           body: S1ScrollNavGroup(
             config: S1ScrollNavConfig(
               showScrollToTop: false,
@@ -109,9 +109,9 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: AppTheme.lightTheme('purple'),
-        home: Scaffold(
+        home: const Scaffold(
           body: S1ScrollNavGroup(
-            config: const S1ScrollNavConfig(
+            config: S1ScrollNavConfig(
               showScrollToTop: true,
               showScrollAdvance: true,
               onScrollToTop: _noop,

--- a/test/widgets/s1_fab_layout_test.dart
+++ b/test/widgets/s1_fab_layout_test.dart
@@ -18,7 +18,7 @@ void main() {
               onScrollToNextFloor: _noop,
               onScrollToBottom: _noop,
             ),
-            primary: S1FabItem(
+            primary: const S1FabItem(
               heroTag: 'reply',
               icon: Icons.edit_outlined,
               tooltip: '回复',
@@ -85,7 +85,8 @@ void main() {
         ),
       ),
     );
-    final upOnly = await navButtonSize(find.byKey(const ValueKey('scroll_nav_up')));
+    final upOnly =
+        await navButtonSize(find.byKey(const ValueKey('scroll_nav_up')));
 
     await tester.pumpWidget(
       MaterialApp(
@@ -121,7 +122,8 @@ void main() {
         ),
       ),
     );
-    final upBoth = await navButtonSize(find.byKey(const ValueKey('scroll_nav_up')));
+    final upBoth =
+        await navButtonSize(find.byKey(const ValueKey('scroll_nav_up')));
     final downBoth =
         await navButtonSize(find.byKey(const ValueKey('scroll_nav_down')));
 
@@ -261,8 +263,7 @@ void main() {
     });
 
     test('shows when remaining distance exceeds 12% viewport', () {
-      final remainingShow =
-          viewport * S1FabLayout.scrollDownShowFraction + 1;
+      const remainingShow = viewport * S1FabLayout.scrollDownShowFraction + 1;
       expect(
         S1FabLayout.shouldShowScrollDown(
           metrics: metrics(maxExtent - remainingShow),
@@ -330,7 +331,7 @@ void main() {
         isTrue,
       );
 
-      final awayFromBottom =
+      const awayFromBottom =
           maxExtent - viewport * S1FabLayout.scrollDownShowFraction - 2;
       expect(
         S1FabLayout.isAtPageBottom(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes analyzer/lint failures blocking `flutter analyze`.

Changes:
- Remove `return null` in `Provider<void>` coordinator.
- Fix scroll action formatting/trailing commas in `ThreadDetailScreen`.
- Fix `scroll_floor_test` by using `unawaited(...)` (avoids test hang/timeout) and add required trailing commas.
- Const/lint cleanups in `s1_fab_layout_test` and `rate_log_card_test`.

Verification:
- `flutter analyze`
- `flutter test`
- `dart run scripts/audit_m3.dart --fail-on-error` (0 P0/P1; WARN-only report written to `reports/m3_audit_2026-07-13.md`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba0c715-61cf-40cf-9d74-8a6a18cda3d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba0c715-61cf-40cf-9d74-8a6a18cda3d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

