### PR TITLE
fix: audit remediation — CI, tests, talker logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  analyze-test-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test --reporter expanded
+
+      - name: M3 audit
+        run: dart run scripts/audit_m3.dart --fail-on-error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ flutter run -d chrome --dart-define=TALKER_LOG_LEVEL=all --dart-define=TALKER_MA
 - 跨客户端备份格式：`docs/backup-format-v1.md`（默认仅 L1 JSON ZIP；`native/` L2 可选且未作为默认导出）
 - 黑名单：仅 Drift 表 + 备份字段预留，产品 UI 尚未实现
 - 表情包资源通过脚本从 GitHub 下载（`scripts/download_emoticons.dart`），未内置到仓库
-- test 目录覆盖率仍不足，尤其是 screens 和 widgets 层
+- test 目录覆盖率仍不足，尤其是 widgets 层（核心 Screen 已补 smoke 测试）
 - 技术栈现代化定案与拆分：`docs/plans/2026-07-12-tech-stack-modernization.md`（P0–P6 已落地后以本文件锁定表为准）
 - flutter_riverpod 临时固定为 `3.2.1`：`3.3.2` 存在上游 [#4765](https://github.com/rrousselGit/riverpod/issues/4765) 的 Provider 订阅恢复期 `markNeedsBuild` 回归；升级前必须先通过路由 Provider 链回归测试。
 
@@ -221,7 +221,8 @@ flutter run -d chrome --dart-define=TALKER_LOG_LEVEL=all --dart-define=TALKER_MA
 > 面向后续 Cloud Agent 的持久化环境说明（依赖已由 update script `flutter pub get` 自动刷新，此处只记录非显而易见的启动/运行注意事项）。
 
 - **Flutter SDK**：预装在 `/home/ubuntu/flutter`（stable，Dart 3.12+），已通过 `~/.bashrc` 加入交互式 shell 的 PATH。非交互式脚本请用全路径 `/home/ubuntu/flutter/bin/flutter`。
-- **Lint / Test**：`flutter analyze`（当前 0 issue）与 `flutter test`（250+ 测试）。注意：**首次** `flutter test` 会一次性编译引擎测试产物，可能数分钟无输出（输出被 shell 缓冲），属正常；产物缓存后整套测试约数秒到十几秒。用 `--reporter expanded` 可看到实时进度。
+- **Lint / Test**：`flutter analyze`（须 0 issue）与 `flutter test`（455+ 测试）。注意：**首次** `flutter test` 会一次性编译引擎测试产物，可能数分钟无输出（输出被 shell 缓冲），属正常；产物缓存后整套测试约数秒到十几秒。用 `--reporter expanded` 可看到实时进度。
+- **CI**：GitHub Actions 工作流 `.github/workflows/ci.yml` 在 push/PR 时运行 `flutter analyze`、`flutter test` 与 `dart run scripts/audit_m3.dart --fail-on-error`。
 - **M3 审计**：`dart run scripts/audit_m3.dart --fail-on-error` 扫描 `lib/`（P0/P1）与 `test/`，报告输出至 `reports/m3_audit_<date>.md`。
 - **运行 Web 开发环境（推荐的可测试目标）**：需要同时启动两个进程（标准命令见 `README.md`）：
   1. CORS 代理：`dart run scripts/proxy_server.dart`，监听 `http://localhost:19080`，转发到 `https://stage1st.com/2b/...` 并处理 CORS/Cookie。

--- a/lib/screens/image_viewer_screen.dart
+++ b/lib/screens/image_viewer_screen.dart
@@ -16,6 +16,7 @@ import '../services/http_client.dart';
 import '../services/s1_image_cache.dart';
 import '../theme/app_theme.dart';
 import '../utils/s1_snack_bar.dart';
+import '../services/talker.dart';
 import '../widgets/web_image_stub.dart'
     if (dart.library.html) '../widgets/web_image_html.dart';
 
@@ -110,7 +111,9 @@ class _ImageViewerScreenState extends ConsumerState<ImageViewerScreen> {
       });
       frameInfo.image.dispose();
       codec.dispose();
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to probe image dimensions', e, st);
+    }
   }
 
   Future<Uint8List?> _tryFetchBytes() async {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -17,6 +17,7 @@ import '../models/rate_form.dart';
 import '../utils/error_handler.dart';
 import 'formhash_service.dart';
 import 'http_client.dart';
+import 'talker.dart';
 
 class LoginRequiredException implements Exception {
   @override
@@ -103,7 +104,9 @@ class ApiService {
     if (data is String) {
       try {
         return jsonDecode(data) as Map<String, dynamic>;
-      } catch (_) {}
+      } catch (e, st) {
+        talker.debug('Failed to decode JSON string response', e, st);
+      }
     }
     return null;
   }
@@ -275,7 +278,9 @@ class ApiService {
     try {
       final url = buildApiUrl(module: ApiConfig.moduleLogin);
       await _httpClient.get(url);
-    } catch (_) {}
+    } catch (e, st) {
+      talker.warning('Guest session warm-up failed', e, st);
+    }
   }
 
   Future<List<Thread>> getThreadList(String fid, {int page = 1}) async {
@@ -334,7 +339,9 @@ class ApiService {
       } else if (initData is String) {
         try {
           initDataMap = jsonDecode(initData) as Map<String, dynamic>;
-        } catch (_) {}
+        } catch (e, st) {
+          talker.debug('Failed to decode login init JSON response', e, st);
+        }
       }
 
       if (initDataMap != null) {
@@ -383,7 +390,9 @@ class ApiService {
       } else if (data is String) {
         try {
           dataMap = jsonDecode(data) as Map<String, dynamic>;
-        } catch (_) {}
+        } catch (e, st) {
+          talker.debug('Failed to decode login response JSON', e, st);
+        }
       }
 
       if (dataMap != null) {
@@ -729,7 +738,9 @@ class ApiService {
         notifyAuthorDefault = notifyAuthor.attributes.containsKey('checked');
         notifyAuthorDisabled = notifyAuthor.attributes.containsKey('disabled');
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to parse rate form HTML', e, st);
+    }
 
     if (scoreOptions.isEmpty) {
       scoreOptions = RateFormOptions.defaultScoreOptions;
@@ -921,7 +932,9 @@ class ApiService {
             );
           }
         }
-      } catch (_) {}
+      } catch (e, st) {
+        talker.debug('Failed to parse profile space extras', e, st);
+      }
 
       return user;
     } catch (_) {
@@ -1286,7 +1299,9 @@ class ApiService {
         _pageCache[cacheKey] = page;
         return page;
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to parse pagination page from HTML', e, st);
+    }
     return 1;
   }
 
@@ -2067,7 +2082,9 @@ class ApiService {
                 .millisecondsSinceEpoch ~/
             1000;
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to parse Chinese date string', e, st);
+    }
     return _parseDateString(normalized);
   }
 

--- a/lib/services/app_local_data.dart
+++ b/lib/services/app_local_data.dart
@@ -6,6 +6,7 @@ import 'package:drift/drift.dart';
 import '../models/reading_record.dart';
 import 'app_database.dart';
 import 'settings_store.dart';
+import 'talker.dart';
 
 /// Local structured data: in-memory mirrors + Drift write-through.
 class AppLocalData {
@@ -97,7 +98,9 @@ class AppLocalData {
               .where((id) => id.isNotEmpty)
               .toList();
         }
-      } catch (_) {}
+      } catch (e, st) {
+        talker.debug('Failed to decode poll vote JSON for ${row.tid}', e, st);
+      }
     }
     _pollVotesLoaded = true;
   }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -94,7 +94,9 @@ class AuthService {
         _isLoggedIn = true;
         return true;
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Session profile check failed, falling back to cookies', e, st);
+    }
 
     // 2. API 验证失败时，检查本地 PersistCookieJar 中是否有 auth Cookie
     //    尝试多个路径以覆盖 Discuz 不同的 Cookie Path 设置
@@ -122,7 +124,9 @@ class AuthService {
           return true;
         }
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Cookie jar session restore failed', e, st);
+    }
     return false;
   }
 }

--- a/lib/services/backup/s1_backup_service.dart
+++ b/lib/services/backup/s1_backup_service.dart
@@ -7,6 +7,7 @@ import '../../models/reading_record.dart';
 import '../app_database.dart';
 import '../app_local_data.dart';
 import 's1_backup_codec.dart';
+import '../talker.dart';
 
 class S1BackupExportResult {
   S1BackupExportResult({
@@ -111,7 +112,9 @@ class S1BackupService {
       try {
         final decoded = jsonDecode(row.scopeJson);
         if (decoded is List) scope = decoded;
-      } catch (_) {}
+      } catch (e, st) {
+        talker.debug('Failed to decode blacklist scope JSON', e, st);
+      }
       return {
         'uid': row.uid,
         'username': row.username,

--- a/lib/services/formhash_service.dart
+++ b/lib/services/formhash_service.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'talker.dart';
+
 class FormhashNotifier extends Notifier<String> {
   @override
   String build() => '';
@@ -31,7 +33,9 @@ class FormhashExtractor {
       if (variables is! Map) return null;
       final formhash = variables['formhash'];
       if (formhash is String && formhash.isNotEmpty) return formhash;
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to extract formhash from API response', e, st);
+    }
     return null;
   }
 

--- a/lib/services/rate_log_service.dart
+++ b/lib/services/rate_log_service.dart
@@ -3,6 +3,7 @@ import 'package:html/parser.dart' show parse;
 import '../config/api_config.dart';
 import '../models/rate_log.dart';
 import 'http_client.dart';
+import 'talker.dart';
 
 class RateLogService {
   RateLogService(this._httpClient);
@@ -127,7 +128,9 @@ class RateLogService {
           );
         }
       }
-    } catch (_) {}
+    } catch (e, st) {
+      talker.debug('Failed to parse rate log block from HTML', e, st);
+    }
 
     if (result.isEmpty && fallbackPid != null && fallbackPid.isNotEmpty) {
       final entries = _parseRatingTable(html);

--- a/test/providers/backup_provider_test.dart
+++ b/test/providers/backup_provider_test.dart
@@ -1,0 +1,165 @@
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:s1_app/providers/backup_provider.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/providers/talker_provider.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/services/app_database.dart';
+import 'package:s1_app/services/app_local_data.dart';
+import 'package:s1_app/services/backup/s1_backup_codec.dart';
+import 'package:s1_app/services/backup/s1_backup_service.dart';
+
+void main() {
+  group('backup provider functions', () {
+    late AppDatabase db;
+    late AppLocalData local;
+    late _RecordingBackupService recordingService;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      local = AppLocalData(db);
+      await local.load();
+      recordingService = _RecordingBackupService(local);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    testWidgets('importS1Backup returns null when pick is cancelled',
+        (tester) async {
+      S1BackupImportResult? result;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            localDataProvider.overrideWithValue(local),
+            s1BackupServiceProvider.overrideWithValue(recordingService),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.lightTheme('purple'),
+            home: _ImportProbe(
+              onDone: (value) => result = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('import'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNull);
+      expect(recordingService.importCalled, isFalse);
+    });
+
+    testWidgets('exportS1Backup invokes service export', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            localDataProvider.overrideWithValue(local),
+            s1BackupServiceProvider.overrideWithValue(recordingService),
+            packageInfoProvider.overrideWith(
+              (_) async => PackageInfo(
+                appName: 'S1',
+                packageName: 'com.example.s1',
+                version: '1.0.0',
+                buildNumber: '1',
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.lightTheme('purple'),
+            home: const _ExportProbe(),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('export'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(recordingService.exportCalled, isTrue);
+    });
+  });
+}
+
+class _ImportProbe extends ConsumerWidget {
+  const _ImportProbe({required this.onDone});
+
+  final void Function(S1BackupImportResult?) onDone;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: FilledButton(
+        onPressed: () async => onDone(await importS1Backup(ref)),
+        child: const Text('import'),
+      ),
+    );
+  }
+}
+
+class _ExportProbe extends ConsumerWidget {
+  const _ExportProbe();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: FilledButton(
+        onPressed: () async {
+          try {
+            await exportS1Backup(ref);
+          } on Object {
+            // Platform share/pick may fail in widget tests.
+          }
+        },
+        child: const Text('export'),
+      ),
+    );
+  }
+}
+
+class _RecordingBackupService extends S1BackupService {
+  _RecordingBackupService(super.local);
+
+  bool exportCalled = false;
+  bool importCalled = false;
+
+  @override
+  Future<S1BackupExportResult> exportL1({
+    required String? uid,
+    required PackageInfo packageInfo,
+    String platform = 'unknown',
+  }) async {
+    exportCalled = true;
+    final payload = S1BackupPayload(
+      manifest: {
+        'format': s1BackupFormatId,
+        'format_version': s1BackupFormatVersion,
+        'exported_at': '2026-07-13T00:00:00Z',
+        'contents': <String>[],
+      },
+    );
+    return S1BackupExportResult(
+      bytes: Uint8List.fromList(const [1, 2, 3]),
+      fileName: 'test.s1backup.zip',
+      payload: payload,
+    );
+  }
+
+  @override
+  Future<S1BackupImportResult> importL1(List<int> bytes) async {
+    importCalled = true;
+    return S1BackupImportResult(
+      readingHistoryUpserts: 0,
+      pollVoteUpserts: 0,
+      blacklistUpserts: 0,
+      settingsApplied: 0,
+    );
+  }
+}

--- a/test/providers/favorite_list_provider_test.dart
+++ b/test/providers/favorite_list_provider_test.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/user.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/favorite_list_provider.dart';
+import 'package:s1_app/services/api_service.dart';
+import 'package:s1_app/services/http_client.dart';
+
+void main() {
+  group('FavoriteListNotifier', () {
+    late _FavoriteListAdapter adapter;
+    late ProviderContainer container;
+
+    setUp(() {
+      adapter = _FavoriteListAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      late ProviderContainer c;
+      c = ProviderContainer(
+        overrides: [
+          httpClientProvider.overrideWith(
+            (ref) => S1HttpClient.test(c, dio),
+          ),
+        ],
+      );
+      container = c;
+      container.read(authStateProvider.notifier).debugSetState(
+            AuthState(
+              isLoggedIn: true,
+              username: 'alice',
+              user: User(uid: '1', username: 'alice'),
+            ),
+          );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('build loads favorite items for logged-in user', () async {
+      final sub = container.listen(
+        favoriteListProvider(FavoriteSegment.thread),
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      final state = await container
+          .read(favoriteListProvider(FavoriteSegment.thread).future);
+
+      expect(adapter.favoriteListRequests, greaterThan(0));
+      expect(state.items, hasLength(1));
+      expect(state.items.single.title, 'Favorite Thread');
+      expect(state.currentPage, 1);
+      expect(state.totalPages, 1);
+    });
+
+    test('build requires login before loading favorites', () async {
+      final adapter = _FavoriteListAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      late ProviderContainer loggedOutContainer;
+      loggedOutContainer = ProviderContainer(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
+          httpClientProvider.overrideWith(
+            (ref) => S1HttpClient.test(loggedOutContainer, dio),
+          ),
+        ],
+      );
+      addTearDown(loggedOutContainer.dispose);
+
+      final sub = loggedOutContainer.listen(
+        favoriteListProvider(FavoriteSegment.thread),
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      await Future<void>.delayed(Duration.zero);
+      final asyncState = loggedOutContainer.read(
+        favoriteListProvider(FavoriteSegment.thread),
+      );
+
+      expect(asyncState.hasError, isTrue);
+      expect(asyncState.error, isA<LoginRequiredException>());
+      expect(adapter.favoriteListRequests, 0);
+    });
+  });
+}
+
+class _FavoriteListAdapter implements HttpClientAdapter {
+  int favoriteListRequests = 0;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final uri = options.uri;
+    if (uri.queryParameters['do'] == 'favorite') {
+      favoriteListRequests++;
+      return ResponseBody.fromString('<html><body></body></html>', 200);
+    }
+    if (uri.queryParameters['module'] == 'myfavthread') {
+      favoriteListRequests++;
+      return ResponseBody.fromString(
+        jsonEncode({
+          'Variables': {
+            'list': [
+              {
+                'favid': '10',
+                'tid': '123',
+                'idtype': 'tid',
+                'title': 'Favorite Thread',
+                'dateline': '1700000000',
+              },
+            ],
+            'count': '1',
+            'perpage': '20',
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    return ResponseBody.fromString('{}', 200);
+  }
+}
+
+class _LoggedOutAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}

--- a/test/providers/forum_list_provider_test.dart
+++ b/test/providers/forum_list_provider_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/providers/forum_list_provider.dart';
+import 'package:s1_app/services/http_client.dart';
+
+void main() {
+  group('ForumListNotifier', () {
+    late _ForumListAdapter adapter;
+    late ProviderContainer container;
+
+    setUp(() {
+      adapter = _ForumListAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      late ProviderContainer c;
+      c = ProviderContainer(
+        overrides: [
+          httpClientProvider.overrideWith(
+            (ref) => S1HttpClient.test(c, dio),
+          ),
+        ],
+      );
+      container = c;
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('build loads forum categories from API', () async {
+      final sub = container.listen(forumListProvider, (_, __) {});
+      addTearDown(sub.close);
+
+      final forums = await container.read(forumListProvider.future);
+
+      expect(adapter.forumIndexRequests, 1);
+      expect(forums, hasLength(1));
+      expect(forums.single.name, '主论坛');
+      expect(forums.single.subforums.single.name, '游戏论坛');
+    });
+
+    test('refresh reloads forum list', () async {
+      final sub = container.listen(forumListProvider, (_, __) {});
+      addTearDown(sub.close);
+
+      await container.read(forumListProvider.future);
+      adapter.forumIndexRequests = 0;
+
+      await container.read(forumListProvider.notifier).refresh();
+      final forums = await container.read(forumListProvider.future);
+
+      expect(adapter.forumIndexRequests, 1);
+      expect(forums.single.subforums.single.fid, '4');
+    });
+  });
+}
+
+class _ForumListAdapter implements HttpClientAdapter {
+  int forumIndexRequests = 0;
+  bool failNext = false;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.uri.queryParameters['module'] == 'forumindex') {
+      forumIndexRequests++;
+      if (failNext) {
+        return ResponseBody.fromString('not json', 500);
+      }
+      return ResponseBody.fromString(
+        jsonEncode({
+          'Variables': {
+            'catlist': [
+              {
+                'fid': '1',
+                'name': '主论坛',
+                'forums': ['4'],
+              },
+            ],
+            'forumlist': [
+              {
+                'fid': '4',
+                'name': '游戏论坛',
+                'description': 'desc',
+                'threads': '10',
+                'posts': '20',
+              },
+            ],
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    return ResponseBody.fromString('{}', 200);
+  }
+}

--- a/test/providers/thread_list_provider_test.dart
+++ b/test/providers/thread_list_provider_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/providers/thread_list_provider.dart';
+import 'package:s1_app/services/http_client.dart';
+
+void main() {
+  group('ThreadListNotifier', () {
+    const fid = '4';
+    late _ThreadListAdapter adapter;
+    late ProviderContainer container;
+
+    setUp(() {
+      adapter = _ThreadListAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      late ProviderContainer c;
+      c = ProviderContainer(
+        overrides: [
+          httpClientProvider.overrideWith(
+            (ref) => S1HttpClient.test(c, dio),
+          ),
+        ],
+      );
+      container = c;
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('build loads first page with forum name', () async {
+      final sub = container.listen(threadListProvider(fid), (_, __) {});
+      addTearDown(sub.close);
+
+      final state = await container.read(threadListProvider(fid).future);
+
+      expect(adapter.forumDisplayRequests, 1);
+      expect(state.forumName, '游戏论坛');
+      expect(state.threads, hasLength(1));
+      expect(state.threads.single.tid, '123');
+      expect(state.currentPage, 1);
+      expect(state.totalPages, 2);
+    });
+
+    test('goToPage loads requested page', () async {
+      final sub = container.listen(threadListProvider(fid), (_, __) {});
+      addTearDown(sub.close);
+
+      await container.read(threadListProvider(fid).future);
+      adapter.forumDisplayRequests = 0;
+
+      await container.read(threadListProvider(fid).notifier).goToPage(2);
+
+      expect(adapter.forumDisplayRequests, 1);
+      final state = container.read(threadListProvider(fid)).asData!.value;
+      expect(state.currentPage, 2);
+      expect(state.threads.single.subject, 'Page 2 Thread');
+    });
+  });
+}
+
+class _ThreadListAdapter implements HttpClientAdapter {
+  int forumDisplayRequests = 0;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.uri.queryParameters['module'] == 'forumdisplay') {
+      forumDisplayRequests++;
+      final page = int.tryParse(options.uri.queryParameters['page'] ?? '1') ?? 1;
+      return ResponseBody.fromString(
+        jsonEncode({
+          'Variables': {
+            'forum': {
+              'name': '游戏论坛',
+              'threads': '60',
+            },
+            'tpp': '30',
+            'forum_threadlist': [
+              {
+                'tid': page == 1 ? '123' : '456',
+                'subject': page == 1 ? 'Test Thread' : 'Page 2 Thread',
+                'author': 'alice',
+                'authorid': '1',
+                'dbdateline': '1700000000',
+                'views': '10',
+                'replies': '2',
+                'fid': '4',
+              },
+            ],
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    return ResponseBody.fromString('{}', 200);
+  }
+}

--- a/test/screens/forum_list_screen_test.dart
+++ b/test/screens/forum_list_screen_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/thread.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/favorite_membership_provider.dart';
+import 'package:s1_app/providers/forum_name_provider.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/providers/thread_list_provider.dart';
+import 'package:s1_app/screens/forum_list_screen.dart';
+import 'package:s1_app/services/app_database.dart';
+import 'package:s1_app/services/app_local_data.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+void main() {
+  const fid = '4';
+  late AppLocalData local;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    local = AppLocalData(db);
+    await local.load();
+  });
+
+  testWidgets('ForumListScreen shows loading indicator', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localDataProvider.overrideWithValue(local),
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          threadListProvider(fid).overrideWith(() => _LoadingThreadListNotifier()),
+          forumNameProvider(fid).overrideWith((ref) => '游戏论坛'),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const ForumListScreen(fid: fid),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.text('游戏论坛'), findsOneWidget);
+  });
+
+  testWidgets('ForumListScreen shows thread list when loaded', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localDataProvider.overrideWithValue(local),
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          threadListProvider(fid).overrideWith(() => _LoadedThreadListNotifier()),
+          forumNameProvider(fid).overrideWith((ref) => '游戏论坛'),
+          favoriteMembershipProvider.overrideWith(() => _IdleFavoriteMembershipNotifier()),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const ForumListScreen(fid: fid),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('游戏论坛'), findsOneWidget);
+    expect(find.text('Test Thread'), findsOneWidget);
+  });
+
+  testWidgets('ForumListScreen shows error view on failure', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localDataProvider.overrideWithValue(local),
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          threadListProvider(fid).overrideWith(() => _ErrorThreadListNotifier()),
+          forumNameProvider(fid).overrideWith((ref) => null),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const ForumListScreen(fid: fid),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('版块 #$fid'), findsOneWidget);
+    expect(find.text('重试'), findsOneWidget);
+  });
+}
+
+class _IdleAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}
+
+class _IdleFavoriteMembershipNotifier extends FavoriteMembershipNotifier {
+  @override
+  FavoriteMembershipState build() => const FavoriteMembershipState();
+}
+
+class _LoadingThreadListNotifier extends ThreadListNotifier {
+  _LoadingThreadListNotifier() : super('4');
+
+  final _completer = Completer<ThreadListState>();
+
+  @override
+  Future<ThreadListState> build() => _completer.future;
+}
+
+class _LoadedThreadListNotifier extends ThreadListNotifier {
+  _LoadedThreadListNotifier() : super('4');
+
+  @override
+  Future<ThreadListState> build() async {
+    return ThreadListState(
+      forumName: '游戏论坛',
+      threads: [
+        Thread(
+          tid: '123',
+          subject: 'Test Thread',
+          author: 'alice',
+          authorId: '1',
+          dateline: 1700000000,
+          views: 10,
+          replies: 2,
+          fid: '4',
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorThreadListNotifier extends ThreadListNotifier {
+  _ErrorThreadListNotifier() : super('4');
+
+  @override
+  Future<ThreadListState> build() async {
+    throw Exception('network failed');
+  }
+}

--- a/test/screens/image_viewer_screen_test.dart
+++ b/test/screens/image_viewer_screen_test.dart
@@ -1,0 +1,89 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/screens/image_viewer_screen.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+// 1x1 transparent PNG
+final _tinyPng = Uint8List.fromList(const <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+  0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+void main() {
+  testWidgets('ImageViewerScreen shows back button and info action',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: ImageViewerScreen(
+            imageUrl: 'https://example.com/image.jpg',
+            imageBytes: _tinyPng,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('返回'), findsOneWidget);
+    expect(find.byTooltip('图片信息'), findsOneWidget);
+  });
+
+  testWidgets('ImageViewerScreen pops when back is pressed', (tester) async {
+    final router = GoRouter(
+      initialLocation: '/viewer',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const Scaffold(
+            body: Center(child: Text('Previous Page')),
+          ),
+          routes: [
+            GoRoute(
+              path: 'viewer',
+              builder: (context, state) => ImageViewerScreen(
+                imageUrl: 'https://example.com/image.jpg',
+                imageBytes: _tinyPng,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+        ],
+        child: MaterialApp.router(
+          theme: AppTheme.lightTheme('purple'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('返回'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Previous Page'), findsOneWidget);
+  });
+}
+
+class _IdleAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/screens/login_screen.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+void main() {
+  testWidgets('LoginScreen renders username, password and login button',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const LoginScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('欢迎回来'), findsOneWidget);
+    expect(find.text('登录您的 Stage1st 账号'), findsOneWidget);
+    expect(find.widgetWithText(TextField, '用户名'), findsOneWidget);
+    expect(find.widgetWithText(TextField, '密码'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '登录'), findsOneWidget);
+  });
+
+  testWidgets('LoginScreen shows validation error when fields are empty',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const LoginScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, '登录'));
+    await tester.pump();
+
+    expect(find.text('用户名和密码不能为空'), findsOneWidget);
+  });
+
+  testWidgets('LoginScreen navigates home after successful login',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/login',
+      routes: [
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const LoginScreen(),
+        ),
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const Scaffold(
+            body: Center(child: Text('Home Page')),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_SuccessfulLoginAuthNotifier.new),
+        ],
+        child: MaterialApp.router(
+          theme: AppTheme.lightTheme('purple'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, '用户名'), 'alice');
+    await tester.enterText(find.widgetWithText(TextField, '密码'), 'secret');
+    await tester.tap(find.widgetWithText(FilledButton, '登录'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home Page'), findsOneWidget);
+  });
+}
+
+class _LoggedOutAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}
+
+class _SuccessfulLoginAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+
+  @override
+  Future<String?> login(String username, String password) async {
+    return null;
+  }
+}

--- a/test/screens/reading_history_screen_test.dart
+++ b/test/screens/reading_history_screen_test.dart
@@ -1,0 +1,87 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/reading_record.dart';
+import 'package:s1_app/providers/reading_history_provider.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/screens/reading_history_screen.dart';
+import 'package:s1_app/services/app_database.dart';
+import 'package:s1_app/services/app_local_data.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+ReadingRecord _sampleRecord() {
+  return ReadingRecord(
+    tid: '100',
+    subject: '测试主题',
+    author: 'alice',
+    fid: '4',
+    lastReadPage: 2,
+    lastReadFloor: 5,
+    totalPages: 3,
+    totalReplies: 80,
+    perPage: 40,
+    lastReadAt: 2000,
+    firstReadAt: 1000,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+  late AppLocalData local;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    local = AppLocalData(db);
+    await local.load();
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('ReadingHistoryScreen shows empty state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localDataProvider.overrideWithValue(local),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const ReadingHistoryScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('阅读历史'), findsOneWidget);
+    expect(find.text('暂无阅读记录'), findsOneWidget);
+  });
+
+  testWidgets('ReadingHistoryScreen shows records when history exists',
+      (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        localDataProvider.overrideWithValue(local),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(readingHistoryBootstrapProvider.future);
+    container.read(readingHistoryProvider.notifier).upsert(_sampleRecord());
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const ReadingHistoryScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('测试主题'), findsOneWidget);
+    expect(find.byIcon(Icons.delete_sweep_outlined), findsOneWidget);
+  });
+}

--- a/test/screens/user_space_screen_test.dart
+++ b/test/screens/user_space_screen_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/user_space_item.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/user_space_provider.dart';
+import 'package:s1_app/screens/user_space_screen.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+void main() {
+  const params = ('42', false);
+
+  testWidgets('UserSpaceScreen shows loading state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          userSpaceProvider(params).overrideWith(() => _LoadingUserSpaceNotifier()),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const UserSpaceScreen(uid: '42', username: 'alice'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('alice 的空间'), findsOneWidget);
+    expect(find.text('主题'), findsOneWidget);
+    expect(find.text('回复'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('UserSpaceScreen shows thread tab content when loaded',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          userSpaceProvider(params).overrideWith(() => _LoadedUserSpaceNotifier()),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const UserSpaceScreen(uid: '42', username: 'alice'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Space Thread'), findsOneWidget);
+  });
+
+  testWidgets('UserSpaceScreen switches to replies tab', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+          userSpaceProvider(params).overrideWith(() => _LoadedUserSpaceNotifier()),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const UserSpaceScreen(uid: '42', username: 'alice'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('回复'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reply excerpt'), findsOneWidget);
+  });
+}
+
+class _IdleAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}
+
+class _LoadingUserSpaceNotifier extends UserSpaceNotifier {
+  _LoadingUserSpaceNotifier() : super(('42', false));
+
+  final _completer = Completer<UserSpaceState>();
+
+  @override
+  Future<UserSpaceState> build() => _completer.future;
+}
+
+class _LoadedUserSpaceNotifier extends UserSpaceNotifier {
+  _LoadedUserSpaceNotifier() : super(('42', false));
+
+  @override
+  Future<UserSpaceState> build() async {
+    return UserSpaceState(
+      threads: [
+        UserSpaceItem(
+          tid: '1',
+          subject: 'Space Thread',
+          dateline: 1700000000,
+        ),
+      ],
+      replies: [
+        UserSpaceItem(
+          tid: '2',
+          subject: 'Reply Thread',
+          dateline: 1700000001,
+          isReply: true,
+          replyExcerpt: 'Reply excerpt',
+          pid: '99',
+        ),
+      ],
+      repliesLoaded: true,
+    );
+  }
+
+  @override
+  Future<void> ensureRepliesLoaded() async {}
+}

--- a/test/utils/scroll_floor_test.dart
+++ b/test/utils/scroll_floor_test.dart
@@ -4,31 +4,31 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/utils/scroll_floor.dart';
 
+import '../helpers/test_theme.dart';
+
 Widget buildScrollHarness({
   required List<GlobalKey> postKeys,
   required ScrollController controller,
   required double postHeight,
   double viewportHeight = 400,
 }) {
-  return MaterialApp(
-    home: Scaffold(
-      body: SizedBox(
-        height: viewportHeight,
-        child: SingleChildScrollView(
-          controller: controller,
-          child: Column(
-            children: [
-              for (var i = 0; i < postKeys.length; i++)
-                SizedBox(
-                  key: postKeys[i],
-                  height: postHeight,
-                  child: Align(
-                    alignment: Alignment.topLeft,
-                    child: Text('Post ${i + 1}'),
-                  ),
+  return wrapWithAppTheme(
+    SizedBox(
+      height: viewportHeight,
+      child: SingleChildScrollView(
+        controller: controller,
+        child: Column(
+          children: [
+            for (var i = 0; i < postKeys.length; i++)
+              SizedBox(
+                key: postKeys[i],
+                height: postHeight,
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text('Post ${i + 1}'),
                 ),
-            ],
-          ),
+              ),
+          ],
         ),
       ),
     ),

--- a/test/utils/scroll_motion_test.dart
+++ b/test/utils/scroll_motion_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/utils/scroll_motion.dart';
 
+import '../helpers/test_theme.dart';
+
 void main() {
   test('durationForDelta scales with distance and caps', () {
     final short = S1ScrollMotion.durationForDelta(80, 600);
@@ -18,17 +20,15 @@ void main() {
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            height: 300,
-            child: ListView.builder(
-              controller: controller,
-              itemCount: 30,
-              itemBuilder: (context, index) => SizedBox(
-                height: 120,
-                child: Text('Item $index'),
-              ),
+      wrapWithAppTheme(
+        SizedBox(
+          height: 300,
+          child: ListView.builder(
+            controller: controller,
+            itemCount: 30,
+            itemBuilder: (context, index) => SizedBox(
+              height: 120,
+              child: Text('Item $index'),
             ),
           ),
         ),

--- a/test/widgets/favorite_bookmark_button_test.dart
+++ b/test/widgets/favorite_bookmark_button_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:s1_app/models/favorite_item.dart';
+import 'package:s1_app/models/user.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/favorite_membership_provider.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/widgets/favorite_bookmark_button.dart';
+
+void main() {
+  testWidgets('FavoriteBookmarkButton redirects to login when logged out',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/forum',
+      routes: [
+        GoRoute(
+          path: '/forum',
+          builder: (context, state) => Scaffold(
+            appBar: AppBar(
+              elevation: 0,
+              actions: const [
+                FavoriteBookmarkButton(
+                  type: FavoriteType.forum,
+                  id: '4',
+                ),
+              ],
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const Scaffold(
+            body: Center(child: Text('Login Page')),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedOutAuthNotifier.new),
+        ],
+        child: MaterialApp.router(
+          theme: AppTheme.lightTheme('purple'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('收藏'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Login Page'), findsOneWidget);
+  });
+
+  testWidgets('FavoriteBookmarkButton shows filled icon when favorited',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedInAuthNotifier.new),
+          favoriteMembershipProvider.overrideWith(
+            () => _FavoritedMembershipNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const Scaffold(
+            body: FavoriteBookmarkButton(
+              type: FavoriteType.thread,
+              id: '123',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.bookmark), findsOneWidget);
+    expect(find.byTooltip('取消收藏'), findsOneWidget);
+  });
+}
+
+class _LoggedOutAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}
+
+class _LoggedInAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState(
+        isLoggedIn: true,
+        username: 'alice',
+        user: User(uid: '1', username: 'alice'),
+      );
+}
+
+class _FavoritedMembershipNotifier extends FavoriteMembershipNotifier {
+  @override
+  FavoriteMembershipState build() {
+    return const FavoriteMembershipState(
+      keys: {'thread:123'},
+    );
+  }
+
+  @override
+  Future<void> ensureSynced() async {}
+}

--- a/test/widgets/lazy_visibility_loader_test.dart
+++ b/test/widgets/lazy_visibility_loader_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1_app/theme/app_theme.dart';
 import 'package:s1_app/widgets/lazy_visibility_loader.dart';
@@ -16,7 +17,7 @@ void main() {
         home: Scaffold(
           body: ListView(
             controller: controller,
-            cacheExtent: 2000,
+            scrollCacheExtent: const ScrollCacheExtent.pixels(2000),
             children: [
               const SizedBox(height: 1200),
               LazyVisibilityLoader(

--- a/test/widgets/post_item_test.dart
+++ b/test/widgets/post_item_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/post.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/widgets/post_item.dart';
+
+Post _samplePost() {
+  return Post(
+    pid: '42',
+    message: 'Hello world',
+    author: 'alice',
+    authorId: '1',
+    dateline: 1704067200,
+    floor: 3,
+  );
+}
+
+void main() {
+  testWidgets('PostItem renders author, message and floor badge', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(initial: const AppSettings()),
+          ),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: Scaffold(
+            body: PostItem(post: _samplePost()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('alice'), findsOneWidget);
+    expect(find.text('Hello world'), findsOneWidget);
+    expect(find.text('#3'), findsOneWidget);
+  });
+
+  testWidgets('PostItem uses highlighted container when isHighlighted',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(initial: const AppSettings()),
+          ),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: Scaffold(
+            body: PostItem(
+              post: _samplePost(),
+              isHighlighted: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final card = tester.widget<Card>(find.byType(Card));
+    final scheme = AppTheme.lightTheme('purple').colorScheme;
+    expect(card.color, scheme.primaryContainer.withValues(alpha: S1Alpha.half));
+  });
+}

--- a/test/widgets/thread_card_test.dart
+++ b/test/widgets/thread_card_test.dart
@@ -1,0 +1,120 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/reading_record.dart';
+import 'package:s1_app/models/thread.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/reading_history_provider.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/services/app_database.dart';
+import 'package:s1_app/services/app_local_data.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/widgets/thread_card.dart';
+
+Thread _sampleThread({String subject = 'Sample Thread'}) {
+  return Thread(
+    tid: '123',
+    subject: subject,
+    author: 'alice',
+    authorId: '1',
+    dateline: 1700000000,
+    views: 100,
+    replies: 5,
+    fid: '4',
+  );
+}
+
+void main() {
+  testWidgets('ThreadCard renders title, author and reply count', (tester) async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(() => db.close());
+    final local = AppLocalData(db);
+    await local.load();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localDataProvider.overrideWithValue(local),
+          authStateProvider.overrideWith(_IdleAuthNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 400,
+                child: ThreadCard(thread: _sampleThread()),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Sample Thread'), findsOneWidget);
+    expect(find.textContaining('alice'), findsOneWidget);
+    expect(find.textContaining('5'), findsWidgets);
+  });
+
+  testWidgets('ThreadCard shows reading progress when record exists',
+      (tester) async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(() => db.close());
+    final local = AppLocalData(db);
+    await local.load();
+
+    final container = ProviderContainer(
+      overrides: [
+        localDataProvider.overrideWithValue(local),
+        authStateProvider.overrideWith(_IdleAuthNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(readingHistoryBootstrapProvider.future);
+    container.read(readingHistoryProvider.notifier).upsert(
+          ReadingRecord(
+            tid: '123',
+            subject: 'Sample Thread',
+            author: 'alice',
+            fid: '4',
+            lastReadPage: 1,
+            lastReadFloor: 10,
+            totalPages: 3,
+            totalReplies: 80,
+            perPage: 40,
+            lastReadAt: 2000,
+            firstReadAt: 1000,
+          ),
+        );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 400,
+                child: ThreadCard(thread: _sampleThread()),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('已读'), findsOneWidget);
+  });
+}
+
+class _IdleAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => AuthState();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the audit remediation plan across four phases:

- **Phase 1:** Fix `flutter analyze` deprecation (`ScrollCacheExtent.pixels`) and clear M3 test WARNs (`wrapWithAppTheme`)
- **Phase 2:** Add GitHub Actions CI (analyze + test + M3 audit)
- **Phase 3:** Add 27 new tests covering 5 screens, 4 providers, and 3 high-traffic widgets
- **Phase 4:** Add Talker logging to previously empty `catch` blocks in services/image viewer; sync `AGENTS.md`

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 455 tests passed
- [x] `dart run scripts/audit_m3.dart --fail-on-error` — 0 WARN

## Not in scope

- `flutter_riverpod` 3.3.2 upgrade (blocked by #4765)
- Blacklist UI productization
- `connectivity_plus` major version bump

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0389f49e-e6f9-4af8-afef-779ac7ae4e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0389f49e-e6f9-4af8-afef-779ac7ae4e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

