### PR TITLE
docs(plans): 更新 S1-Next 接口对齐报告

### DIFF
--- a/docs/plans/2026-07-14-search.md
+++ b/docs/plans/2026-07-14-search.md
@@ -1,0 +1,151 @@
+# 搜索功能落地计划
+
+> 依据：[S1-Next 接口对照](./s1-next-api-gap.md)「优先缺口」第 1 项  
+> 对照：[S1-Next](https://github.com/ykrank/S1-Next) `SearchActivity` / `searchForum` / `searchUser` + HTML Wrapper  
+> 入口：已有底部 Tab「搜索」占位（`HomeScreen` 登录态 index 1）  
+> 日期：2026-07-14
+
+## 1. 目标与非目标
+
+### 目标（本计划 = Search MVP）
+
+登录用户可在「搜索」Tab：
+
+1. 按 **主题** 搜索（`search.php?mod=forum`）
+2. 按 **用户** 搜索（`search.php?mod=user`）
+3. 主题结果点击进入帖子详情；用户结果打开资料 sheet / 用户空间
+4. 主题结果支持分页（对齐其它列表：`PaginationBar` / swipe）
+5. 空结果、鉴权失败、限流（`allowsearch` 间隔）有可读错误提示
+
+### 非目标（本里程碑不做）
+
+| 项 | 原因 |
+|----|------|
+| 游客搜索 Tab | 现状游客不显示搜索/消息；Discuz 搜索依赖 formhash + 登录 |
+| App API 搜索 | 整组 App API 跳过 |
+| 搜索历史 / 联想 / 高级筛选（版块、时间、作者） | 可后置 |
+| 把结果当原始 HTML 富文本整块渲染（S1-Next 主题结果做法） | 我们改为结构化字段 + ListTile，便于 M3 / 导航 |
+| 私信详情、`mynotelist`、发帖 | 属 gap 报告后续里程碑（见 §7） |
+
+## 2. 后端契约（对齐 S1-Next）
+
+| | 主题搜索 | 用户搜索 |
+|--|----------|----------|
+| Method | `POST` | `POST` |
+| URL | `{base}/search.php?searchsubmit=yes&mod=forum` | `…&mod=user` |
+| Body | `formhash` + `srchtxt` | 同左 |
+| 响应 | HTML | HTML |
+| 解析锚点 | 计数 `em`「找到 “…” 相关内容 N 个」；结果 `li.pbw`；分页 `div.pg` | 错误 `div#messagetext`；结果 `li.bbda.cl` → uid + name |
+
+`formhash`：复用现有 `formhashProvider` / `FormhashExtractor`；缺失时用一次只读 GET（如 `forumindex`）预热，**禁止**绕过 `S1HttpClient`。
+
+限流：用户组常有 `allowsearch`（如 30s）。失败文案透传 / 友好化，客户端可做简单「提交冷却」避免连点。
+
+## 3. 架构（遵守分层）
+
+```
+SearchScreen (Tab body)
+  → searchProvider / SearchNotifier   # 编排 query、type、page、loading/error
+    → ApiService.searchForum / searchUser
+      → S1HttpClient
+```
+
+| 层 | 职责 |
+|----|------|
+| `models/search_*.dart` | 纯 Dart：`ForumSearchHit`、`UserSearchHit`、`ForumSearchResult`（含 count/page/maxPage/pageHref） |
+| `services/api_service.dart` | `searchForum` / `searchUser` + HTML 解析（`package:html`，与评分/收藏一致） |
+| `providers/search_provider.dart` | 持有 `SearchType`、query、当前页；debounce 不必要（仅 submit 触发） |
+| `screens/search_screen.dart` | `SearchBar` + `SegmentedButton`（主题/用户）+ 列表 |
+| `widgets/` | `ForumSearchTile` / `UserSearchTile`（可内嵌 screen 私有 widget，复用再上提） |
+
+**禁止**：Screen 直调 Dio；Model 依赖 Flutter。
+
+## 4. UI 方案
+
+替换 `home_screen.dart` 中：
+
+```dart
+tabIndex == 1 ? const Center(child: Text('搜索')) : …
+```
+
+为 `const SearchScreen()`。
+
+| 区域 | 组件 | 说明 |
+|------|------|------|
+| 类型 | `SegmentedButton`：主题 / 用户 | 对齐消息 Tab；切换清空结果或保留各自缓存（优先清空，实现简单） |
+| 输入 | M3 `SearchBar`（或 `TextField` + 提交） | IME `search`；提交后收键盘 |
+| 主题结果 | 标题、版块/作者/时间、摘要一行 | 点进 `/thread/{tid}`；tid 从结果 `thread-` / `mod=viewthread&tid=` 解析 |
+| 用户结果 | 头像 + 用户名 | 点进 `showUserProfileSheet` 或 `/user/{uid}`（与现有用户入口一致） |
+| 分页 | 主题：有 `maxPage` 时显示分页条；用户：通常一页 | 翻页：优先用结果里的 `pageHref` 模板 `page=`，否则带同 query 再 POST（以 spike 实测为准） |
+| 状态 | 初始 hint、loading、空「未找到 “q”」、`S1ErrorView` | AppBar：Tab 外层已是「Stage1st」；可在 Search 内不再套第二 AppBar |
+
+颜色 / 字号一律 `colorScheme` / `textTheme`；`Card`/`AppBar` `elevation: 0`。
+
+## 5. 分 PR 落地
+
+### PR-A — Spike + 契约固化（可与 B 合并若一次做完）
+
+1. **一次**登录探测（慎用测试账号，禁止循环）：对「主题」「用户」各打 1 次 `search.php`，保存脱敏 HTML 到 `test/fixtures/search_forum.html` / `search_user.html`（及空结果、限流若可得）。
+2. 更新 `docs/api_reference.md` 搜索小节。
+3. 确认：相对 URL、tid 形态、分页 href、限流文案。
+
+**验收**：fixture 可被离线解析单测吃掉；文档写明 POST 字段。
+
+### PR-B — Service + 解析 + 测试（核心）
+
+1. `ApiConfig`：`searchForumUrl` / `searchUserUrl`（或常量 path）。
+2. `ApiService.searchForum({query, page?})` / `searchUser({query})`。
+3. 解析逻辑对齐 S1-Next 选择器；主题结果 **结构化提取**（不要整段 HTML 丢给 UI）。
+4. 单测：fixture → hits / count / pages / 错误节点。
+
+**验收**：`flutter test` 覆盖解析；`flutter analyze` 干净。
+
+### PR-C — Provider + SearchScreen 接入 Tab
+
+1. `SearchNotifier`：`submit` / `goToPage` / `setType`。
+2. `SearchScreen` 替占位。
+3. 导航：主题 → `context.push('/thread/…')`；用户 → 现有 profile 路径。
+4. 可选：Widget 烟测（`wrapWithAppTheme`）— 提交后出现假数据列表。
+
+**验收**：Web 登录后搜索 Tab 可用；主题可进帖、用户可看资料；错误路径有提示。
+
+### PR-D（可并入 C）— 主题分页 + 冷却
+
+1. 分页条与状态同步。
+2. 提交按钮 / 请求期间防连点；识别「请稍候」类限流文案。
+
+## 6. 风险与对策
+
+| 风险 | 对策 |
+|------|------|
+| HTML 结构变动 | 选择器对齐 S1-Next；fixture 锁回归；解析失败记 Talker + 友好错误 |
+| 搜索需登录 / CSRF | Tab 仅登录可见；强制带 formhash |
+| 测试账号风控 | Spike 各类型 **最多 1～2 次**；之后全靠 fixture |
+| 主题结果链接多样 | 多 pattern 提 tid（`thread-{tid}-`、`tid=`、`viewthread`） |
+| 分页二次请求形态不明 | Spike 先定：沿用 `href` GET 还是再次 POST `srchtxt` |
+
+## 7. 搜索之后的路线图（不在本计划编码范围）
+
+来自 gap 报告建议顺序，本计划完成后建议：
+
+1. **私信会话详情** `mypm&subop=view`（去掉外链浏览器）
+2. 通知体验（可选 `mynotelist`）/ 黑名单 `pm` 过滤
+3. 写操作：`newthread` → `sendpm` → 编辑 / 举报
+4. 周边：签到、好友、服务端黑名单、小黑屋
+
+## 8. Definition of Done（Search MVP）
+
+- [ ] 登录态搜索 Tab：主题 / 用户均可查
+- [ ] 核心解析有 fixture 单测
+- [ ] 异常：未登录、空结果、限流、网络错误有用户可见提示
+- [ ] `flutter analyze` / 相关 `flutter test` 通过
+- [ ] M3 审计无新增 CRITICAL
+- [ ] 更新 gap 报告：搜索行 → **已实现**（或写清仍缺高级筛选等子缺口）
+
+## 9. 建议开工顺序
+
+1. 写本计划 ✅  
+2. PR-A fixture + `api_reference`  
+3. PR-B Service/解析  
+4. PR-C UI 接 Tab  
+5. 回写 `s1-next-api-gap.md`  

--- a/docs/plans/s1-next-api-gap.md
+++ b/docs/plans/s1-next-api-gap.md
@@ -91,7 +91,8 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 
 1. **只读/本地（适合 S1 繁忙或暂缓写操作时）**  
    搜索 → 私信会话详情（`mypm&subop=view`）→ 通知体验（可选切 `mynotelist` JSON）  
-   本地黑名单：补 `pm` scope 过滤（可选）；服务端同步仍后置
+   本地黑名单：补 `pm` scope 过滤（可选）；服务端同步仍后置  
+   → **搜索执行计划**：[2026-07-14-search.md](./2026-07-14-search.md)
 2. **写操作（等论坛稳定后再开）**  
    发新帖 `newthread` → 发私信 `sendpm` → 编辑 / 举报
 3. **社交周边（可后置）**  

--- a/docs/plans/s1-next-api-gap.md
+++ b/docs/plans/s1-next-api-gap.md
@@ -1,21 +1,24 @@
 # S1-Next 接口对照
 
-> 对照源：[S1-Next](https://github.com/ykrank/S1-Next) `v3.0.87-alpha` 的 `S1Service` / `ApiForum` / `ApiHome` / `ApiMember`  
-> 我方以 `lib/services/api_service.dart` + [`docs/api_reference.md`](../api_reference.md) 为准  
-> 上次更新：2026-07-14
+> 对照源：[S1-Next](https://github.com/ykrank/S1-Next) `master` @ `20a14fdb43`（`alpha 3.3.95`；最近标签 `v3.0.87-alpha`）  
+> 读取文件：`S1Service` / `ApiForum` / `ApiHome` / `ApiMember` / `AppService`  
+> 我方以 `lib/services/api_service.dart` + `lib/config/api_config.dart` + [`docs/api_reference.md`](../api_reference.md) 为准（`main` @ 本文件提交时）  
+> 上次更新：2026-07-14（黑名单 MVP 合入后重审；修正摘要计数；PM 详情入口澄清）
 
 对话旁的 Cursor Canvas 副本在本机：
 `~/.cursor/projects/d-Project-s1-app/canvases/s1-next-api-gap.canvas.tsx`  
-（**不进 git**；以本文档为项目内权威版本。）
+（**不进 git**；以本文档为项目内权威版本。Canvas 可能过期，勿单独当真相源。）
 
 ## 摘要
 
-| 状态 | 含义 | 约数 |
+| 状态 | 含义 | 条数 |
 |------|------|------|
-| 已实现 | 功能等价 | 17 |
-| 部分 | 有替代路径但不完整 | 2 |
-| 未实现 | 无客户端能力 | 8 |
+| 已实现 | Discuz 能力功能等价（路径可不同） | 17 |
+| 部分 | 有替代路径但不完整 | 3 |
+| 未实现 | 无客户端能力 | 9 |
 | 不做/边缘 | 可不跟 | 1 + App API 整组 |
+
+计数口径：下表「Discuz 接口全表」每一行算 1 条（不含 App API 子表）。「收藏版块」属我方多出的已实现项，计入 17。
 
 ### 两套后端
 
@@ -26,29 +29,29 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 
 | 能力 | S1-Next | 我们 | 说明 |
 |------|---------|------|------|
+| 搜索（版块/用户） | `search.php mod=forum\|user` | — | **只读最高价值缺口** |
+| 私信会话详情 | `mypm&subop=view` | 仅列表 → 外链浏览器打开网页 | 部分 |
+| 提醒/通知 | `module=mynotelist`（含系统提醒） | `home.php do=notice` HTML | 部分；未用 JSON |
 | 发新主题 | `module=newthread` + 预取页面 | — | docs 实测可用；写操作暂缓 |
+| 发私信 | `module=sendpm` | `ApiConfig.moduleSendMessage` 仅常量 | docs 实测可用；UI/调用未接 |
 | 编辑帖子 | `forum.php action=edit` | — | Mobile `editpost` 禁用，只能走 Web |
-| 搜索（版块/用户） | `search.php mod=forum\|user` | — | 适合只读阶段 |
 | 举报 | `misc.php?mod=report` | — | 次常用写操作 |
-| 发私信 | `module=sendpm` | — | docs 实测可用 |
 | 好友列表 | `module=friend` | 仅 friends 计数 | 周边 |
 | 每日签到 | `study_daily_attendance…` | — | 周边 |
 | 小黑屋 | `forum.php showdarkroom ajax` | — | 周边 |
-| 服务端黑名单 | `home.php friend&view=blacklist` | 本地黑名单 MVP（无服务端同步） | 周边 |
-| 本地黑名单 | 本地库 hide/del | UI + `thread`/`post` 过滤；`pm` 预留 | 部分 |
-| 私信会话详情 | `mypm&subop=view` | 仅列表 / WebView 入口 | 部分 |
-| 提醒/通知 | `module=mynotelist` | `home.php do=notice` HTML | 部分；未用 JSON |
+| 服务端黑名单 | `home.php friend&view=blacklist` | 不同步网页黑名单 | 周边 |
+| 本地黑名单 | 本地库 hide/del | Drift + `/blacklist` UI；`thread`/`post` 已滤；`pm` 可存不筛 | 部分（MVP 已合入） |
 
 ## Discuz 接口全表
 
 | 能力 | S1-Next 端点 | 我们 | 状态 |
 |------|--------------|------|------|
-| 版块首页 | `module=forumindex` | `forumindex` | 已实现 |
-| 帖子列表 | `module=forumdisplay` | `forumdisplay` | 已实现 |
-| 帖子详情 | `module=viewthread` (v1/v4) | `viewthread` v4 | 已实现 |
-| 登录（含安全提问） | `module=login` | `login` | 已实现 |
-| 刷新 formhash | `module=toplist` | viewthread / forumindex / login | 已实现（路径不同，等价） |
-| 回复 | `module=sendreply` | `sendReply()` → `module=sendreply` | 已实现（2026-07 已对齐；旧 forum.php reply 仅遗留） |
+| 版块首页 | `module=forumindex` | `getForumList()` → `forumindex` | 已实现 |
+| 帖子列表 | `module=forumdisplay`（含 `typeid`） | `getThreadList(Raw)`；解析 `typeId`，**未传 `typeid` 筛选** | 已实现 |
+| 帖子详情 | `viewthread` v1/`URL_POST_LIST_NEW` v4（含 `authorid`） | `getThreadDetail` v4 + `authorId`；楼内「只看该作者」已接 | 已实现 |
+| 登录（含安全提问） | `module=login` | `login()` + 安全提问 | 已实现 |
+| 刷新 formhash | `module=toplist` | viewthread / forumindex / login 响应提取 | 已实现（路径不同，等价） |
+| 回复 | `module=sendreply` | `sendReply()` → `module=sendreply` | 已实现（2026-07 对齐；旧 `forum.php` reply 仅 `@Deprecated` 遗留） |
 | 引用回复助手 | `forum.php action=reply` (quote helper) | `fetchQuoteInfo()` + `noticetrimstr` | 已实现 |
 | 回复插图（外链图床） | `p.sda1.dev upload_external_noform` | `ExternalImageUploadService`（Web 经 `/ext-upload`） | 已实现 |
 | 麻将脸表情 | 本地 assets + 实体码 | `assets/emoticons` + `ComposeEmoticonPanel` | 已实现 |
@@ -57,34 +60,38 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 | 编辑帖子 | `forum.php action=edit` | — | 未实现 |
 | 搜索（版块/用户） | `search.php mod=forum\|user` | — | 未实现 |
 | 投票 | `forum.php action=votepoll` | `votePoll()` | 已实现 |
-| 评分 / 评分日志 | `action=rate` + `viewratings` | `fetchRateForm` / `submitRate` / RateLogService | 已实现 |
+| 评分 / 评分日志 | `action=rate` + `viewratings` | `fetchRateForm` / `submitRate` / `RateLogService` | 已实现 |
 | 举报 | `misc.php?mod=report` | — | 未实现 |
-| 收藏主题 增删查 | `myfavthread` / `favthread` | HTML `home.php` + JSON 兜底 | 已实现 |
-| 收藏版块 | —（S1-Next 仅主题） | `myfavforum` + HTML | 已实现（我们多出） |
-| 私信会话列表 | `module=mypm` | `mypm` + HTML 兜底 | 已实现 |
-| 私信会话详情 | `mypm&subop=view` | —（仅列表 / WebView） | 部分 |
-| 发私信 | `module=sendpm` | — | 未实现 |
-| 提醒/通知 | `module=mynotelist` | `home.php do=notice` HTML | 部分 |
-| 用户资料 | `module=profile` | `profile` | 已实现 |
-| 好友列表 | `module=friend` | 仅展示 friends 计数 | 未实现 |
+| 收藏主题 增删查 | `myfavthread` / `favthread` | 查：JSON `myfavthread` + HTML；增删：`home.php` HTML（非 Mobile `favthread`） | 已实现 |
+| 收藏版块 | —（S1-Next 仅主题） | `myfavforum` + HTML 增删 | 已实现（我们多出） |
+| 私信会话列表 | `module=mypm` | `getPmList()` JSON + HTML 兜底 | 已实现 |
+| 私信会话详情 | `mypm&subop=view` | —；列表点击 `launchUrl` 外链网页 | 部分 |
+| 发私信 | `module=sendpm` | 常量预留，无 Service/UI | 未实现 |
+| 提醒/通知 | `mynotelist`（mypost + system） | `getNoticeList()` → `home.php do=notice` HTML | 部分 |
+| 用户资料 | `module=profile`（另有 profile Web） | `getUserProfile` / `getUserProfileByUid` | 已实现 |
+| 好友列表 | `module=friend` | 仅展示 `friends` 计数 | 未实现 |
 | 用户主题/回复 | `home.php space thread/reply` | `getUserSpaceList` / `getMySpaceList` | 已实现 |
 | 每日签到 | `study_daily_attendance…` | — | 未实现 |
 | 小黑屋 | `forum.php showdarkroom ajax` | — | 未实现 |
 | 服务端黑名单 | `home.php friend&view=blacklist` | —（不同步网页黑名单） | 未实现 |
-| 本地黑名单 | 本地库 hide/del | Drift + `/blacklist` UI；`thread` 滤列表、`post` 折叠楼层；`pm` 可存不筛 | 部分 |
+| 本地黑名单 | 本地库 hide/del | Drift + `/blacklist`；`thread` 滤列表、`post` 折叠楼层；`pm` scope 可存不筛；备份 `blacklist.json` | 部分 |
 | 交易贴信息 | `viewthread&do=tradeinfo` | — | 不做/边缘 |
 
 ## S1-Next App API（跳过）
 
+基址：`https://app.saraba1st.com/2b/api/app/`（`AppApi.BASE_URL`）
+
 | 能力 | S1-Next | 我们 |
 |------|---------|------|
-| App 用户信息 / 登录 / 签到 | `app.saraba1st.com …/user*` | 不使用 |
-| App 帖子分页 / 投票 | `…/thread*`、`/poll*` | 不使用（走 Discuz） |
+| App 用户信息 / 登录 / 签到 | `user` / `user/login` / `user/sign` | 不使用 |
+| App 帖子分页 / 帖信息 | `thread/page` / `thread` | 不使用（走 Discuz `viewthread`） |
+| App 投票读/写 | `poll/poll` / `poll/options` / `poll/vote` | 不使用（走 Discuz `votepoll`） |
 
 ## 建议落地顺序
 
 1. **只读/本地（适合 S1 繁忙或暂缓写操作时）**  
-   搜索、私信会话详情、通知体验（本地黑名单 UI+过滤已部分落地）
+   搜索 → 私信会话详情（`mypm&subop=view`）→ 通知体验（可选切 `mynotelist` JSON）  
+   本地黑名单：补 `pm` scope 过滤（可选）；服务端同步仍后置
 2. **写操作（等论坛稳定后再开）**  
    发新帖 `newthread` → 发私信 `sendpm` → 编辑 / 举报
 3. **社交周边（可后置）**  
@@ -92,8 +99,11 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 
 ## 实现差异备注
 
-- **回复端点**：已与 S1-Next 对齐为 `module=sendreply`；旧 `forum.php` reply 仅作遗留对照。
-- **收藏**：他们偏 Mobile `favthread`；我们主路径是 `home.php` HTML，并多了收藏版块。
-- **通知**：他们用 `mynotelist` JSON；我们用 notice HTML 列表（可读已可用）。
+- **回复端点**：已与 S1-Next 对齐为 `module=sendreply`；旧 `forum.php` reply 仅作遗留对照（`sendPost` `@Deprecated`）。
+- **收藏**：他们查 `myfavthread`、增删偏 Mobile `favthread`；我们查 JSON + HTML 兜底，增删主路径是 `home.php`，并多了收藏版块。
+- **通知**：他们用 `mynotelist` JSON（帖内提醒 + 系统提醒分接口）；我们用 notice HTML 列表（可读已可用）。
+- **私信详情**：他们原生拉 `mypm&subop=view`；我们列表后跳外部浏览器，无应用内会话页、无 `sendpm`。
+- **forumdisplay `typeid`**：S1-Next 请求带分类筛选；我们展示分类标签，但不按 `typeid` 请求过滤（子能力缺口，不单列未实现）。
 - **登出**：双方都是清 Cookie/会话，无独立 Discuz logout module 依赖。
-- **本地黑名单**：设备级（主键为被拉黑 `uid`）；`scope`=`thread`/`post`/`pm`（`pm` 预留）；楼层默认折叠可展开，非硬删；与 `blacklist.json` 备份往返兼容。不接网页好友黑名单同步。
+- **本地黑名单**：设备级（主键被拉黑 `uid`）；`scope`=`thread`/`post`/`pm`（`pm` 预留）；楼层默认折叠可展开，非硬删；与 `blacklist.json` 备份往返兼容。不接网页好友黑名单同步。MVP 已合入 `main`（#25）。
+- **死常量**：`ApiConfig.moduleSendMessage` / `moduleFavThread` / `moduleFavForum` 已声明，当前无调用方；接 `sendpm` 或切 Mobile 收藏时可复用。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

更新 S1-Next 接口对齐文档，并拟定搜索 MVP 落地计划。

### 1. `docs/plans/s1-next-api-gap.md`
- 对照源钉死 S1-Next `master` @ `20a14fdb43`（`alpha 3.3.95`）
- 修正摘要计数：17 / 3 / 9
- 澄清 PM 外链入口、本地黑名单 MVP、子能力差异
- 链接至搜索执行计划

### 2. `docs/plans/2026-07-14-search.md`（新）
按 gap 报告第 1 优先项拟定 Search MVP：
- **PR-A** Spike + HTML fixtures + `api_reference`
- **PR-B** `ApiService.searchForum/User` + 结构化解析 + 单测
- **PR-C** `SearchScreen` 替换 Tab 占位 + Provider
- **PR-D** 主题分页 + 搜索冷却

入口复用已有「搜索」Tab；POST `search.php` + formhash，对齐 S1-Next。

无应用代码变更。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f607b-150b-7cb8-8223-ffb8a4fbb76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f607b-150b-7cb8-8223-ffb8a4fbb76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

