### PR TITLE
feat(search): 搜索 Tab（主题 / 用户）

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -17,6 +17,8 @@ S1 论坛使用的 Discuz! Mobile API (version=4)。所有请求走 `ApiConfig.m
 | `sendpm` | 发私信 | 未使用 | ❌ 未实现 | — |
 | `mypm` | 私信会话列表 | `getPmList()` | ✅ 已完成 | ✅ 已通过（未登录探测） |
 | `sendreply` | **发回复（当前路径）** | `sendReply()` | ✅ 已完成 | ✅ 模块存在 |
+| `search.php?mod=forum` | 主题搜索（HTML） | `searchForum()` | ✅ 已完成 | ⚠️ 服务器过载时未复测；fixture 单测 |
+| `search.php?mod=user` | 用户搜索（HTML） | `searchUser()` | ✅ 已完成 | ⚠️ 同上 |
 | `sendpost` | ⚠️ **S1 已禁用**（勿与 sendreply 混淆） | — | ❌ 不存在 | |
 | `editpost` | ⚠️ **S1 已禁用** | — | ❌ 不存在 |
 | `uploadattach` / `postattach` | ⚠️ **S1 已禁用** | — | ❌ 不存在 |
@@ -24,6 +26,24 @@ S1 论坛使用的 Discuz! Mobile API (version=4)。所有请求走 `ApiConfig.m
 | `forum.php?mod=post&action=reply` | 旧 Web 回复（已弃用） | `sendPost()` `@Deprecated` | ⚠️ 遗留 | |
 | `forum.php?mod=post&action=edit` | 编辑帖子 | 未实现 | 📄 仅文档 | — |
 | 外链图床 `p.sda1.dev` | 回复插图 → `[img]url[/img]` | `ExternalImageUploadService` | ✅ 已完成 | |
+
+---
+
+## search.php（主题 / 用户搜索）
+
+> 对齐 S1-Next：`POST /2b/search.php?searchsubmit=yes&mod=forum|user`，body 含 `formhash` + `srchtxt`。响应为 HTML（非 Mobile JSON）。
+
+| | 主题 `mod=forum` | 用户 `mod=user` |
+|--|------------------|-----------------|
+| 入口 | 登录态「搜索」Tab → 主题 | 同 Tab → 用户 |
+| 首次请求 | POST + formhash | POST + formhash |
+| 翻页 | GET `pageHref`（`searchid` + `page=`） | 通常单页 |
+| 解析 | `em` 计数、`li.pbw`、`div.pg` | `li.bbda.cl` → uid/name；`#messagetext` 错误 |
+| 限流 | 用户组 `allowsearch`（常见 30s）；客户端另有 30s 提交冷却 | 同左 |
+
+主题结果结构化为 `tid` / 标题 / 摘要 / 版块 / 作者 / 时间，点击进 `/thread/{tid}`。用户结果打开资料 sheet。
+
+**注意**：2026-07-14 服务端曾返回过载文案，直播抓包未完成；解析回归依赖 `test/fixtures/search_*.html`。
 
 ---
 

--- a/docs/plans/s1-next-api-gap.md
+++ b/docs/plans/s1-next-api-gap.md
@@ -1,15 +1,9 @@
 # S1-Next 接口对照
 
-<<<<<<< HEAD
-> 对照源：[S1-Next](https://github.com/ykrank/S1-Next) `v3.0.87-alpha` 的 `S1Service` / `ApiForum` / `ApiHome` / `ApiMember`  
-> 我方以 `lib/services/api_service.dart` + [`docs/api_reference.md`](../api_reference.md) 为准  
-> 上次更新：2026-07-14（搜索 Tab MVP 落地）
-=======
 > 对照源：[S1-Next](https://github.com/ykrank/S1-Next) `master` @ `20a14fdb43`（`alpha 3.3.95`；最近标签 `v3.0.87-alpha`）  
 > 读取文件：`S1Service` / `ApiForum` / `ApiHome` / `ApiMember` / `AppService`  
 > 我方以 `lib/services/api_service.dart` + `lib/config/api_config.dart` + [`docs/api_reference.md`](../api_reference.md) 为准（`main` @ 本文件提交时）  
-> 上次更新：2026-07-14（黑名单 MVP 合入后重审；修正摘要计数；PM 详情入口澄清）
->>>>>>> origin/main
+> 上次更新：2026-07-14（搜索 Tab MVP 落地；衔接 #26 对齐报告重审）
 
 对话旁的 Cursor Canvas 副本在本机：
 `~/.cursor/projects/d-Project-s1-app/canvases/s1-next-api-gap.canvas.tsx`  
@@ -19,18 +13,12 @@
 
 | 状态 | 含义 | 条数 |
 |------|------|------|
-<<<<<<< HEAD
-| 已实现 | 功能等价 | 18 |
+| 已实现 | Discuz 能力功能等价（路径可不同） | 18 |
 | 部分 | 有替代路径但不完整 | 3 |
 | 未实现 | 无客户端能力 | 8 |
-=======
-| 已实现 | Discuz 能力功能等价（路径可不同） | 17 |
-| 部分 | 有替代路径但不完整 | 3 |
-| 未实现 | 无客户端能力 | 9 |
->>>>>>> origin/main
 | 不做/边缘 | 可不跟 | 1 + App API 整组 |
 
-计数口径：下表「Discuz 接口全表」每一行算 1 条（不含 App API 子表）。「收藏版块」属我方多出的已实现项，计入 17。
+计数口径：下表「Discuz 接口全表」每一行算 1 条（不含 App API 子表）。「收藏版块」属我方多出的已实现项；搜索 MVP 已计入 18。
 
 ### 两套后端
 
@@ -41,8 +29,7 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 
 | 能力 | S1-Next | 我们 | 说明 |
 |------|---------|------|------|
-| 搜索（版块/用户） | `search.php mod=forum\|user` | — | **只读最高价值缺口** |
-| 私信会话详情 | `mypm&subop=view` | 仅列表 → 外链浏览器打开网页 | 部分 |
+| 私信会话详情 | `mypm&subop=view` | 仅列表 → 外链浏览器打开网页 | 部分；**只读下一优先** |
 | 提醒/通知 | `module=mynotelist`（含系统提醒） | `home.php do=notice` HTML | 部分；未用 JSON |
 | 发新主题 | `module=newthread` + 预取页面 | — | docs 实测可用；写操作暂缓 |
 | 发私信 | `module=sendpm` | `ApiConfig.moduleSendMessage` 仅常量 | docs 实测可用；UI/调用未接 |
@@ -102,13 +89,8 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 ## 建议落地顺序
 
 1. **只读/本地（适合 S1 繁忙或暂缓写操作时）**  
-<<<<<<< HEAD
-   ~~搜索~~（已落地）→ 私信会话详情、通知体验（本地黑名单 UI+过滤已部分落地）
-=======
-   搜索 → 私信会话详情（`mypm&subop=view`）→ 通知体验（可选切 `mynotelist` JSON）  
-   本地黑名单：补 `pm` scope 过滤（可选）；服务端同步仍后置  
-   → **搜索执行计划**：[2026-07-14-search.md](./2026-07-14-search.md)
->>>>>>> origin/main
+   ~~搜索~~（已落地；计划见 [2026-07-14-search.md](./2026-07-14-search.md)）→ 私信会话详情（`mypm&subop=view`）→ 通知体验（可选切 `mynotelist` JSON）  
+   本地黑名单：补 `pm` scope 过滤（可选）；服务端同步仍后置
 2. **写操作（等论坛稳定后再开）**  
    发新帖 `newthread` → 发私信 `sendpm` → 编辑 / 举报
 3. **社交周边（可后置）**  
@@ -116,18 +98,12 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 
 ## 实现差异备注
 
-<<<<<<< HEAD
-- **回复端点**：已与 S1-Next 对齐为 `module=sendreply`；旧 `forum.php` reply 仅作遗留对照。
-- **搜索**：对齐 `search.php` HTML；主题结果结构化提取（非整段 HTML 渲染）；客户端 30s 提交冷却。
-- **收藏**：他们偏 Mobile `favthread`；我们主路径是 `home.php` HTML，并多了收藏版块。
-- **通知**：他们用 `mynotelist` JSON；我们用 notice HTML 列表（可读已可用）。
-=======
 - **回复端点**：已与 S1-Next 对齐为 `module=sendreply`；旧 `forum.php` reply 仅作遗留对照（`sendPost` `@Deprecated`）。
+- **搜索**：对齐 `search.php` HTML；主题结果结构化提取（非整段 HTML 渲染）；客户端 30s 提交冷却。
 - **收藏**：他们查 `myfavthread`、增删偏 Mobile `favthread`；我们查 JSON + HTML 兜底，增删主路径是 `home.php`，并多了收藏版块。
 - **通知**：他们用 `mynotelist` JSON（帖内提醒 + 系统提醒分接口）；我们用 notice HTML 列表（可读已可用）。
 - **私信详情**：他们原生拉 `mypm&subop=view`；我们列表后跳外部浏览器，无应用内会话页、无 `sendpm`。
 - **forumdisplay `typeid`**：S1-Next 请求带分类筛选；我们展示分类标签，但不按 `typeid` 请求过滤（子能力缺口，不单列未实现）。
->>>>>>> origin/main
 - **登出**：双方都是清 Cookie/会话，无独立 Discuz logout module 依赖。
 - **本地黑名单**：设备级（主键被拉黑 `uid`）；`scope`=`thread`/`post`/`pm`（`pm` 预留）；楼层默认折叠可展开，非硬删；与 `blacklist.json` 备份往返兼容。不接网页好友黑名单同步。MVP 已合入 `main`（#25）。
-- **死常量**：`ApiConfig.moduleSendMessage` / `moduleFavThread` / `moduleFavForum` 已声明，当前无调用方；接 `sendpm` 或切 Mobile 收藏时可复用。
+- **死常量**：`ApiConfig.moduleSendMessage` / `moduleFavThread` / `moduleFavForum` 已声明；`moduleSendMessage` 接 `sendpm`、或切 Mobile 收藏时复用 `moduleFav*`。

--- a/docs/plans/s1-next-api-gap.md
+++ b/docs/plans/s1-next-api-gap.md
@@ -2,7 +2,7 @@
 
 > 对照源：[S1-Next](https://github.com/ykrank/S1-Next) `v3.0.87-alpha` 的 `S1Service` / `ApiForum` / `ApiHome` / `ApiMember`  
 > 我方以 `lib/services/api_service.dart` + [`docs/api_reference.md`](../api_reference.md) 为准  
-> 上次更新：2026-07-14
+> 上次更新：2026-07-14（搜索 Tab MVP 落地）
 
 对话旁的 Cursor Canvas 副本在本机：
 `~/.cursor/projects/d-Project-s1-app/canvases/s1-next-api-gap.canvas.tsx`  
@@ -12,8 +12,8 @@
 
 | 状态 | 含义 | 约数 |
 |------|------|------|
-| 已实现 | 功能等价 | 17 |
-| 部分 | 有替代路径但不完整 | 2 |
+| 已实现 | 功能等价 | 18 |
+| 部分 | 有替代路径但不完整 | 3 |
 | 未实现 | 无客户端能力 | 8 |
 | 不做/边缘 | 可不跟 | 1 + App API 整组 |
 
@@ -28,7 +28,6 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 |------|---------|------|------|
 | 发新主题 | `module=newthread` + 预取页面 | — | docs 实测可用；写操作暂缓 |
 | 编辑帖子 | `forum.php action=edit` | — | Mobile `editpost` 禁用，只能走 Web |
-| 搜索（版块/用户） | `search.php mod=forum\|user` | — | 适合只读阶段 |
 | 举报 | `misc.php?mod=report` | — | 次常用写操作 |
 | 发私信 | `module=sendpm` | — | docs 实测可用 |
 | 好友列表 | `module=friend` | 仅 friends 计数 | 周边 |
@@ -55,7 +54,7 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 | 定位楼层页码 | `forum.php redirect=findpost` | `locatePostPage()` | 已实现 |
 | 发新主题 | `module=newthread` + 预取页面 | — | 未实现 |
 | 编辑帖子 | `forum.php action=edit` | — | 未实现 |
-| 搜索（版块/用户） | `search.php mod=forum\|user` | — | 未实现 |
+| 搜索（版块/用户） | `search.php mod=forum\|user` | `searchForum()` / `searchUser()` + 搜索 Tab | 已实现 |
 | 投票 | `forum.php action=votepoll` | `votePoll()` | 已实现 |
 | 评分 / 评分日志 | `action=rate` + `viewratings` | `fetchRateForm` / `submitRate` / RateLogService | 已实现 |
 | 举报 | `misc.php?mod=report` | — | 未实现 |
@@ -84,7 +83,7 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 ## 建议落地顺序
 
 1. **只读/本地（适合 S1 繁忙或暂缓写操作时）**  
-   搜索、私信会话详情、通知体验（本地黑名单 UI+过滤已部分落地）
+   ~~搜索~~（已落地）→ 私信会话详情、通知体验（本地黑名单 UI+过滤已部分落地）
 2. **写操作（等论坛稳定后再开）**  
    发新帖 `newthread` → 发私信 `sendpm` → 编辑 / 举报
 3. **社交周边（可后置）**  
@@ -93,6 +92,7 @@ S1-Next 同时打 Discuz Mobile / `forum.php`，以及独立 App API（`https://
 ## 实现差异备注
 
 - **回复端点**：已与 S1-Next 对齐为 `module=sendreply`；旧 `forum.php` reply 仅作遗留对照。
+- **搜索**：对齐 `search.php` HTML；主题结果结构化提取（非整段 HTML 渲染）；客户端 30s 提交冷却。
 - **收藏**：他们偏 Mobile `favthread`；我们主路径是 `home.php` HTML，并多了收藏版块。
 - **通知**：他们用 `mynotelist` JSON；我们用 notice HTML 列表（可读已可用）。
 - **登出**：双方都是清 Cookie/会话，无独立 Discuz logout module 依赖。

--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -37,4 +37,13 @@ class ApiConfig {
   static const String moduleFavThread = 'favthread';
   static const String moduleFavForum = 'favforum';
   static const String moduleSendReply = 'sendreply';
+
+  /// Discuz 搜索（HTML）：主题 / 用户。
+  static String searchForumUrl({int? page}) {
+    final pageQuery = page == null ? '' : '&page=$page';
+    return '$baseUrl/search.php?searchsubmit=yes&mod=forum$pageQuery';
+  }
+
+  static String searchUserUrl() =>
+      '$baseUrl/search.php?searchsubmit=yes&mod=user';
 }

--- a/lib/models/search_result.dart
+++ b/lib/models/search_result.dart
@@ -1,0 +1,64 @@
+/// 搜索类型：主题（论坛帖）/ 用户。
+enum SearchType { forum, user }
+
+class ForumSearchHit {
+  const ForumSearchHit({
+    required this.tid,
+    required this.title,
+    this.snippet = '',
+    this.forumName = '',
+    this.author = '',
+    this.dateline = '',
+  });
+
+  final String tid;
+  final String title;
+  final String snippet;
+  final String forumName;
+  final String author;
+  final String dateline;
+}
+
+class UserSearchHit {
+  const UserSearchHit({
+    required this.uid,
+    required this.name,
+  });
+
+  final String uid;
+  final String name;
+}
+
+class ForumSearchPage {
+  const ForumSearchPage({
+    this.hits = const [],
+    this.count = 0,
+    this.currentPage = 1,
+    this.totalPages = 1,
+    this.pageHref = '',
+    this.error,
+  });
+
+  final List<ForumSearchHit> hits;
+  final int count;
+  final int currentPage;
+  final int totalPages;
+
+  /// 分页 URL 模板，含 `page=` 后缀（页码为空，由调用方拼接）。
+  final String pageHref;
+  final String? error;
+
+  bool get hasError => error != null && error!.isNotEmpty;
+}
+
+class UserSearchPage {
+  const UserSearchPage({
+    this.hits = const [],
+    this.error,
+  });
+
+  final List<UserSearchHit> hits;
+  final String? error;
+
+  bool get hasError => error != null && error!.isNotEmpty;
+}

--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/search_result.dart';
+import '../services/api_service.dart';
+import '../utils/error_handler.dart';
+import 'api_service_provider.dart';
+
+/// Discuz `allowsearch` 常见间隔；客户端提交冷却，降低连点触发限流。
+const searchSubmitCooldown = Duration(seconds: 30);
+
+class SearchUiState {
+  const SearchUiState({
+    this.type = SearchType.forum,
+    this.query = '',
+    this.forumHits = const [],
+    this.userHits = const [],
+    this.count = 0,
+    this.currentPage = 1,
+    this.totalPages = 1,
+    this.pageHref = '',
+    this.isLoading = false,
+    this.hasSearched = false,
+    this.error,
+    this.cooldownUntil,
+  });
+
+  final SearchType type;
+  final String query;
+  final List<ForumSearchHit> forumHits;
+  final List<UserSearchHit> userHits;
+  final int count;
+  final int currentPage;
+  final int totalPages;
+  final String pageHref;
+  final bool isLoading;
+  final bool hasSearched;
+  final Object? error;
+  final DateTime? cooldownUntil;
+
+  bool get isCoolingDown {
+    final until = cooldownUntil;
+    if (until == null) return false;
+    return DateTime.now().isBefore(until);
+  }
+
+  Duration? get cooldownRemaining {
+    final until = cooldownUntil;
+    if (until == null) return null;
+    final left = until.difference(DateTime.now());
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  SearchUiState copyWith({
+    SearchType? type,
+    String? query,
+    List<ForumSearchHit>? forumHits,
+    List<UserSearchHit>? userHits,
+    int? count,
+    int? currentPage,
+    int? totalPages,
+    String? pageHref,
+    bool? isLoading,
+    bool? hasSearched,
+    Object? error,
+    bool clearError = false,
+    DateTime? cooldownUntil,
+    bool clearCooldown = false,
+  }) {
+    return SearchUiState(
+      type: type ?? this.type,
+      query: query ?? this.query,
+      forumHits: forumHits ?? this.forumHits,
+      userHits: userHits ?? this.userHits,
+      count: count ?? this.count,
+      currentPage: currentPage ?? this.currentPage,
+      totalPages: totalPages ?? this.totalPages,
+      pageHref: pageHref ?? this.pageHref,
+      isLoading: isLoading ?? this.isLoading,
+      hasSearched: hasSearched ?? this.hasSearched,
+      error: clearError ? null : (error ?? this.error),
+      cooldownUntil:
+          clearCooldown ? null : (cooldownUntil ?? this.cooldownUntil),
+    );
+  }
+}
+
+class SearchNotifier extends Notifier<SearchUiState> {
+  @override
+  SearchUiState build() => const SearchUiState();
+
+  ApiService get _api => ref.read(apiServiceProvider);
+
+  void setType(SearchType type) {
+    if (type == state.type) return;
+    state = SearchUiState(
+      type: type,
+      cooldownUntil: state.cooldownUntil,
+    );
+  }
+
+  Future<void> submit(String rawQuery) async {
+    final query = rawQuery.trim();
+    if (query.isEmpty) {
+      state = state.copyWith(error: '请输入搜索关键词', hasSearched: false);
+      return;
+    }
+    if (state.isLoading) return;
+    if (state.isCoolingDown) {
+      final sec = state.cooldownRemaining?.inSeconds ?? 0;
+      state = state.copyWith(
+        error: '搜索过于频繁，请 $sec 秒后再试',
+      );
+      return;
+    }
+
+    state = state.copyWith(
+      isLoading: true,
+      clearError: true,
+      query: query,
+      hasSearched: true,
+    );
+
+    try {
+      if (state.type == SearchType.forum) {
+        final page = await _api.searchForum(query: query);
+        _applyForumPage(page, query: query);
+      } else {
+        final page = await _api.searchUser(query: query);
+        _applyUserPage(page, query: query);
+      }
+    } on LoginRequiredException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e,
+        forumHits: const [],
+        userHits: const [],
+      );
+    } catch (e, st) {
+      state = state.copyWith(
+        isLoading: false,
+        error: friendlyError(e, '搜索', st),
+        forumHits: const [],
+        userHits: const [],
+      );
+    }
+  }
+
+  Future<void> goToPage(int page) async {
+    if (state.type != SearchType.forum) return;
+    if (page < 1 || page > state.totalPages || page == state.currentPage) {
+      return;
+    }
+    if (state.isLoading) return;
+    final query = state.query;
+    if (query.isEmpty) return;
+
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final result = await _api.searchForum(
+        query: query,
+        page: page,
+        pageHref: state.pageHref.isEmpty ? null : state.pageHref,
+      );
+      _applyForumPage(result, query: query, startCooldown: false);
+    } on LoginRequiredException catch (e) {
+      state = state.copyWith(isLoading: false, error: e);
+    } catch (e, st) {
+      state = state.copyWith(
+        isLoading: false,
+        error: friendlyError(e, '搜索翻页', st),
+      );
+    }
+  }
+
+  void _applyForumPage(
+    ForumSearchPage page, {
+    required String query,
+    bool startCooldown = true,
+  }) {
+    state = state.copyWith(
+      isLoading: false,
+      query: query,
+      hasSearched: true,
+      forumHits: page.hits,
+      userHits: const [],
+      count: page.count,
+      currentPage: page.currentPage,
+      totalPages: page.totalPages < 1 ? 1 : page.totalPages,
+      pageHref: page.pageHref,
+      error: page.error,
+      clearError: !page.hasError,
+      cooldownUntil: startCooldown
+          ? DateTime.now().add(searchSubmitCooldown)
+          : state.cooldownUntil,
+    );
+  }
+
+  void _applyUserPage(UserSearchPage page, {required String query}) {
+    state = state.copyWith(
+      isLoading: false,
+      query: query,
+      hasSearched: true,
+      userHits: page.hits,
+      forumHits: const [],
+      count: page.hits.length,
+      currentPage: 1,
+      totalPages: 1,
+      pageHref: '',
+      error: page.error,
+      clearError: !page.hasError,
+      cooldownUntil: DateTime.now().add(searchSubmitCooldown),
+    );
+  }
+}
+
+final searchProvider =
+    NotifierProvider.autoDispose<SearchNotifier, SearchUiState>(
+  SearchNotifier.new,
+);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,8 +14,9 @@ import '../widgets/app_bar_more_menu.dart';
 import '../widgets/s1_error_view.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
-import 'profile_screen.dart';
 import 'messages_screen.dart';
+import 'search_screen.dart';
+import 'profile_screen.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -109,7 +110,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ? tabIndex == 0
               ? const _ForumTab()
               : tabIndex == 1
-                  ? const Center(child: Text('搜索'))
+                  ? const SearchScreen()
                   : tabIndex == 2
                       ? const MessagesScreen()
                       : const ProfileBody(

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,0 +1,387 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../models/search_result.dart';
+import '../models/user.dart';
+import '../providers/search_provider.dart';
+import '../providers/user_profile_provider.dart';
+import '../theme/app_theme.dart';
+import '../widgets/s1_error_view.dart';
+import '../widgets/pagination_bar.dart';
+import '../widgets/user_profile_sheet.dart';
+import '../widgets/web_avatar.dart';
+
+class SearchScreen extends ConsumerStatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  ConsumerState<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends ConsumerState<SearchScreen> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    await ref.read(searchProvider.notifier).submit(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final state = ref.watch(searchProvider);
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: SegmentedButton<SearchType>(
+            segments: const [
+              ButtonSegment(
+                value: SearchType.forum,
+                label: Text('主题'),
+                icon: Icon(Icons.article_outlined),
+              ),
+              ButtonSegment(
+                value: SearchType.user,
+                label: Text('用户'),
+                icon: Icon(Icons.person_outline),
+              ),
+            ],
+            selected: {state.type},
+            onSelectionChanged: state.isLoading
+                ? null
+                : (value) {
+                    ref.read(searchProvider.notifier).setType(value.first);
+                    _controller.clear();
+                  },
+            style: S1SegmentedButtonStyle.forScheme(scheme),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: SearchBar(
+            controller: _controller,
+            focusNode: _focusNode,
+            hintText: state.type == SearchType.forum ? '搜索主题…' : '搜索用户…',
+            leading: const Icon(Icons.search),
+            trailing: [
+              if (_controller.text.isNotEmpty)
+                IconButton(
+                  tooltip: '清除',
+                  onPressed: state.isLoading
+                      ? null
+                      : () {
+                          _controller.clear();
+                          setState(() {});
+                        },
+                  icon: const Icon(Icons.clear),
+                ),
+              IconButton(
+                tooltip: '搜索',
+                onPressed: state.isLoading ? null : _submit,
+                icon: state.isLoading
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: scheme.primary,
+                        ),
+                      )
+                    : const Icon(Icons.arrow_forward),
+              ),
+            ],
+            onChanged: (_) => setState(() {}),
+            onSubmitted: (_) => _submit(),
+          ),
+        ),
+        if (state.isCoolingDown && state.hasSearched)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              '搜索冷却中，约 ${state.cooldownRemaining?.inSeconds ?? 0} 秒后可再次提交',
+              style: textTheme.bodySmall?.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        Expanded(child: _SearchBody(controller: _controller)),
+      ],
+    );
+  }
+}
+
+class _SearchBody extends ConsumerWidget {
+  const _SearchBody({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(searchProvider);
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    if (state.isLoading && !state.hasSearched) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null &&
+        state.forumHits.isEmpty &&
+        state.userHits.isEmpty) {
+      final err = state.error!;
+      if (err is Exception) {
+        return S1ErrorView(
+          error: err,
+          onRetry: () =>
+              ref.read(searchProvider.notifier).submit(controller.text),
+          onLogin: () => context.push('/login'),
+        );
+      }
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline, size: 48, color: scheme.error),
+              const SizedBox(height: 16),
+              Text(
+                err.toString(),
+                textAlign: TextAlign.center,
+                style: textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              FilledButton.tonal(
+                onPressed: state.isLoading
+                    ? null
+                    : () => ref
+                        .read(searchProvider.notifier)
+                        .submit(controller.text),
+                child: const Text('重试'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (!state.hasSearched) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.search,
+                size: 48,
+                color: scheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                state.type == SearchType.forum ? '搜索主题与帖子' : '搜索用户',
+                style: textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '输入关键词后按回车或点击箭头',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (state.type == SearchType.forum) {
+      if (state.forumHits.isEmpty) {
+        return _EmptyResult(query: state.query);
+      }
+      return Column(
+        children: [
+          if (state.count > 0)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  '找到 ${state.count} 条结果',
+                  style: textTheme.labelLarge?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+          Expanded(
+            child: Stack(
+              children: [
+                ListView.builder(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  itemCount: state.forumHits.length,
+                  itemBuilder: (context, index) {
+                    final hit = state.forumHits[index];
+                    return _ForumHitTile(hit: hit);
+                  },
+                ),
+                if (state.isLoading)
+                  const Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    child: LinearProgressIndicator(),
+                  ),
+              ],
+            ),
+          ),
+          if (state.totalPages > 1)
+            PaginationBar(
+              currentPage: state.currentPage,
+              totalPages: state.totalPages,
+              onPageChanged: (page) =>
+                  ref.read(searchProvider.notifier).goToPage(page),
+              sheetSubtitle: state.query,
+            ),
+        ],
+      );
+    }
+
+    if (state.userHits.isEmpty) {
+      return _EmptyResult(query: state.query);
+    }
+    return Stack(
+      children: [
+        ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          itemCount: state.userHits.length,
+          itemBuilder: (context, index) {
+            final hit = state.userHits[index];
+            return _UserHitTile(hit: hit);
+          },
+        ),
+        if (state.isLoading)
+          const Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: LinearProgressIndicator(),
+          ),
+      ],
+    );
+  }
+}
+
+class _EmptyResult extends StatelessWidget {
+  const _EmptyResult({required this.query});
+
+  final String query;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(
+          '未找到 “$query” 相关结果',
+          textAlign: TextAlign.center,
+          style: textTheme.bodyLarge?.copyWith(
+            color: scheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ForumHitTile extends StatelessWidget {
+  const _ForumHitTile({required this.hit});
+
+  final ForumSearchHit hit;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final meta = [
+      if (hit.forumName.isNotEmpty) hit.forumName,
+      if (hit.author.isNotEmpty) hit.author,
+      if (hit.dateline.isNotEmpty) hit.dateline,
+    ].join(' · ');
+
+    return ListTile(
+      title: Text(hit.title, maxLines: 2, overflow: TextOverflow.ellipsis),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (hit.snippet.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              hit.snippet,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.bodySmall?.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+          if (meta.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              meta,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.labelSmall?.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+      isThreeLine: hit.snippet.isNotEmpty,
+      onTap: () => context.push('/thread/${hit.tid}'),
+    );
+  }
+}
+
+class _UserHitTile extends ConsumerWidget {
+  const _UserHitTile({required this.hit});
+
+  final UserSearchHit hit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final avatarUrl = User.resolveAvatarUrl(
+      'https://avatar.stage1st.com/avatar.php?uid=${hit.uid}&size=small',
+    );
+
+    return ListTile(
+      leading: WebAvatar(
+        url: avatarUrl,
+        radius: 20,
+        fallbackLetter: hit.name.isNotEmpty ? hit.name[0] : '?',
+      ),
+      title: Text(hit.name),
+      onTap: () {
+        showUserProfileSheet(
+          context,
+          future: ref.read(userProfileProvider(hit.uid).future),
+        );
+      },
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -15,6 +15,7 @@ import '../models/notice_item.dart';
 import '../models/favorite_item.dart';
 import '../models/message_list_result.dart';
 import '../models/rate_form.dart';
+import '../models/search_result.dart';
 import '../models/app_exceptions.dart';
 import '../utils/error_handler.dart';
 import '../utils/discuz_message.dart';
@@ -2268,6 +2269,274 @@ class ApiService {
     } catch (_) {
       return null;
     }
+  }
+
+  /// 主题搜索（`search.php?mod=forum`）。
+  ///
+  /// 首页：POST `formhash` + `srchtxt`。翻页：优先 GET [pageHref] 模板。
+  Future<ForumSearchPage> searchForum({
+    required String query,
+    int page = 1,
+    String? pageHref,
+  }) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return const ForumSearchPage(error: '请输入搜索关键词');
+    }
+
+    try {
+      final String body;
+      if (page > 1 && pageHref != null && pageHref.isNotEmpty) {
+        final url = _resolveSearchPageUrl(pageHref, page);
+        final response = await _httpClient.get(
+          url,
+          options: Options(responseType: ResponseType.plain),
+        );
+        body = response.data?.toString() ?? '';
+      } else {
+        final hasFormhash = await _httpClient.ensureFormhash(force: true);
+        if (!hasFormhash) {
+          return const ForumSearchPage(error: '无法获取表单验证串，请刷新后重试');
+        }
+        final response = await _httpClient.post(
+          ApiConfig.searchForumUrl(),
+          data: <String, String>{'srchtxt': trimmed},
+          options: Options(
+            contentType: Headers.formUrlEncodedContentType,
+            responseType: ResponseType.plain,
+          ),
+        );
+        body = response.data?.toString() ?? '';
+      }
+      return parseForumSearchHtml(body);
+    } on LoginRequiredException {
+      rethrow;
+    } catch (e, st) {
+      return ForumSearchPage(error: friendlyError(e, '搜索主题', st));
+    }
+  }
+
+  /// 用户搜索（`search.php?mod=user`）。
+  Future<UserSearchPage> searchUser({required String query}) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return const UserSearchPage(error: '请输入搜索关键词');
+    }
+
+    try {
+      final hasFormhash = await _httpClient.ensureFormhash(force: true);
+      if (!hasFormhash) {
+        return const UserSearchPage(error: '无法获取表单验证串，请刷新后重试');
+      }
+      final response = await _httpClient.post(
+        ApiConfig.searchUserUrl(),
+        data: <String, String>{'srchtxt': trimmed},
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          responseType: ResponseType.plain,
+        ),
+      );
+      final body = response.data?.toString() ?? '';
+      return parseUserSearchHtml(body);
+    } on LoginRequiredException {
+      rethrow;
+    } catch (e, st) {
+      return UserSearchPage(error: friendlyError(e, '搜索用户', st));
+    }
+  }
+
+  static String _resolveSearchPageUrl(String pageHref, int page) {
+    final trimmed = pageHref.trim();
+    if (trimmed.contains('page=')) {
+      final withPage = trimmed.replaceFirst(RegExp(r'page=\d*'), 'page=$page');
+      return trimmed.startsWith('http')
+          ? withPage
+          : '${ApiConfig.baseUrl}/$withPage'.replaceFirst(
+              '${ApiConfig.baseUrl}//',
+              '${ApiConfig.baseUrl}/',
+            );
+    }
+    final join = trimmed.contains('?') ? '&' : '?';
+    final path = trimmed.startsWith('http')
+        ? trimmed
+        : '${ApiConfig.baseUrl}/$trimmed'.replaceFirst(
+            '${ApiConfig.baseUrl}//',
+            '${ApiConfig.baseUrl}/',
+          );
+    return '$path${join}page=$page';
+  }
+
+  /// 解析主题搜索 HTML（对齐 S1-Next `ForumSearchWrapper`）。
+  static ForumSearchPage parseForumSearchHtml(String html) {
+    if (html.contains('id="loginform_') || html.contains('name="login"')) {
+      throw LoginRequiredException();
+    }
+
+    final messageError = _extractMessagetextError(html);
+    if (messageError != null && messageError.isNotEmpty) {
+      return ForumSearchPage(error: messageError);
+    }
+
+    final doc = parse(html);
+    var count = 0;
+    for (final em in doc.querySelectorAll('em')) {
+      final text = em.text.trim();
+      final match =
+          RegExp(r'找到\s*[“"](.+?)[”"]\s*相关内容\s*(\d+)\s*个').firstMatch(text);
+      if (match != null) {
+        count = int.tryParse(match.group(2) ?? '') ?? 0;
+        break;
+      }
+    }
+
+    if (count == 0 && doc.querySelectorAll('li.pbw').isEmpty) {
+      return const ForumSearchPage(count: 0);
+    }
+
+    final hits = <ForumSearchHit>[];
+    for (final li in doc.querySelectorAll('li.pbw')) {
+      final hit = _parseForumSearchHit(li.outerHtml);
+      if (hit != null) hits.add(hit);
+    }
+
+    var currentPage = 1;
+    var totalPages = 1;
+    var pageHref = '';
+    final pg = doc.querySelector('div.pg');
+    if (pg != null) {
+      final strong = pg.querySelector('strong');
+      currentPage = int.tryParse(strong?.text.trim() ?? '') ?? 1;
+      final spanTitle = pg.querySelector('span[title]');
+      final titleText = spanTitle?.attributes['title'] ?? spanTitle?.text ?? '';
+      final maxMatch = RegExp(r'(\d+)').firstMatch(titleText);
+      if (maxMatch != null) {
+        totalPages = int.tryParse(maxMatch.group(1) ?? '') ?? 1;
+      }
+      final firstLink = pg.querySelector('a[href]');
+      final href = firstLink?.attributes['href'] ?? '';
+      if (href.isNotEmpty) {
+        pageHref = href.replaceFirst(RegExp(r'page=\d+'), 'page=');
+      }
+      if (totalPages < currentPage) totalPages = currentPage;
+    }
+
+    return ForumSearchPage(
+      hits: hits,
+      count: count > 0 ? count : hits.length,
+      currentPage: currentPage,
+      totalPages: totalPages,
+      pageHref: pageHref,
+    );
+  }
+
+  static ForumSearchHit? _parseForumSearchHit(String block) {
+    final tidMatch = RegExp(
+      r'thread-(\d+)-|(?:[?&]|&amp;)tid=(\d+)',
+      caseSensitive: false,
+    ).firstMatch(block);
+    final tid = tidMatch?.group(1) ?? tidMatch?.group(2) ?? '';
+    if (tid.isEmpty) return null;
+
+    final titleMatch = RegExp(
+      r'<h3[^>]*>\s*<a[^>]*>(.*?)</a>',
+      caseSensitive: false,
+      dotAll: true,
+    ).firstMatch(block);
+    final title = titleMatch != null
+        ? _stripHtml(titleMatch.group(1) ?? '')
+        : '';
+    if (title.isEmpty) return null;
+
+    final paragraphs = RegExp(
+      r'<p[^>]*>(.*?)</p>',
+      caseSensitive: false,
+      dotAll: true,
+    ).allMatches(block).map((m) => m.group(1) ?? '').toList();
+
+    var snippet = '';
+    var forumName = '';
+    var author = '';
+    var dateline = '';
+
+    if (paragraphs.isNotEmpty) {
+      // 末段通常含版块 / 作者 / 时间；中间段为摘要。
+      final metaHtml = paragraphs.last;
+      final metaText = _stripHtml(metaHtml);
+      final parts = metaText
+          .split(RegExp(r'\s*-\s*'))
+          .map((e) => e.trim())
+          .where((e) => e.isNotEmpty)
+          .toList();
+      if (parts.isNotEmpty) forumName = parts[0];
+      if (parts.length >= 2) author = parts[1];
+      if (parts.length >= 3) dateline = parts.sublist(2).join(' - ');
+
+      for (var i = 0; i < paragraphs.length - 1; i++) {
+        final text = _stripHtml(paragraphs[i]);
+        if (text.isEmpty) continue;
+        if (text.startsWith('本帖最后由')) continue;
+        snippet = text;
+        break;
+      }
+    }
+
+    return ForumSearchHit(
+      tid: tid,
+      title: title,
+      snippet: snippet,
+      forumName: forumName,
+      author: author,
+      dateline: dateline,
+    );
+  }
+
+  /// 解析用户搜索 HTML（对齐 S1-Next `UserSearchWrapper`）。
+  static UserSearchPage parseUserSearchHtml(String html) {
+    if (html.contains('id="loginform_') || html.contains('name="login"')) {
+      throw LoginRequiredException();
+    }
+
+    final messageError = _extractMessagetextError(html);
+    if (messageError != null && messageError.isNotEmpty) {
+      return UserSearchPage(error: messageError);
+    }
+
+    final doc = parse(html);
+    final hits = <UserSearchHit>[];
+    for (final li in doc.querySelectorAll('li.bbda.cl, li.bbda')) {
+      final hit = _parseUserSearchHit(li.outerHtml);
+      if (hit != null) hits.add(hit);
+    }
+    return UserSearchPage(hits: hits);
+  }
+
+  static UserSearchHit? _parseUserSearchHit(String block) {
+    final uidMatch = RegExp(
+      r'space-uid-(\d+)|[?&]uid=(\d+)|uid[=/](\d+)',
+      caseSensitive: false,
+    ).firstMatch(block);
+    final uid = uidMatch?.group(1) ??
+        uidMatch?.group(2) ??
+        uidMatch?.group(3) ??
+        '';
+    if (uid.isEmpty) return null;
+
+    // 优先取用户名链接文本（跳过头像链接内的空/img）。
+    final nameMatches = RegExp(
+      r'<a[^>]*href="[^"]*(?:space-uid-|uid=)[^"]*"[^>]*>(.*?)</a>',
+      caseSensitive: false,
+      dotAll: true,
+    ).allMatches(block);
+    var name = '';
+    for (final match in nameMatches) {
+      final text = _stripHtml(match.group(1) ?? '');
+      if (text.isNotEmpty) {
+        name = text;
+        break;
+      }
+    }
+    if (name.isEmpty) return null;
+    return UserSearchHit(uid: uid, name: name);
   }
 }
 

--- a/test/config/api_config_test.dart
+++ b/test/config/api_config_test.dart
@@ -18,4 +18,19 @@ void main() {
     expect(referer, contains('mobile=2'));
     expect(referer, contains('handlekey=postform'));
   });
+
+  test('searchForumUrl / searchUserUrl match Discuz search.php', () {
+    expect(
+      ApiConfig.searchForumUrl(),
+      'https://stage1st.com/2b/search.php?searchsubmit=yes&mod=forum',
+    );
+    expect(
+      ApiConfig.searchForumUrl(page: 2),
+      contains('mod=forum&page=2'),
+    );
+    expect(
+      ApiConfig.searchUserUrl(),
+      'https://stage1st.com/2b/search.php?searchsubmit=yes&mod=user',
+    );
+  });
 }

--- a/test/fixtures/search_forum.html
+++ b/test/fixtures/search_forum.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><title>搜索 - Stage1st</title></head>
+<body>
+<div id="ct" class="wp cl">
+  <h1 class="xs2"><em>找到 “switch” 相关内容 128 个</em></h1>
+  <div class="slst mtw">
+    <ul>
+      <li class="pbw" id="2265001">
+        <h3 class="xs3">
+          <a href="thread-2265001-1-1.html" target="_blank">Switch 2 发布会汇总讨论</a>
+        </h3>
+        <p class="xg1">本帖最后由 somebody 于 2026-7-1 12:00 编辑</p>
+        <p>关于 switch 的长篇讨论与泄漏汇总……</p>
+        <p>
+          <span><a href="forum.php?mod=forumdisplay&amp;fid=4">游戏论坛</a></span>
+           -
+          <span><a href="home.php?mod=space&amp;uid=10001">alice</a></span>
+           -
+          2026-7-1
+        </p>
+      </li>
+      <li class="pbw" id="2201002">
+        <h3 class="xs3">
+          <a href="forum.php?mod=viewthread&amp;tid=2201002" target="_blank">求推荐 switch 独立游戏</a>
+        </h3>
+        <p>最近想买 switch，求推荐……</p>
+        <p>
+          <span>电玩事务所</span>
+           -
+          <span><a href="space-uid-20002.html">bob</a></span>
+           -
+          2026-6-15
+        </p>
+      </li>
+    </ul>
+  </div>
+  <div class="pg">
+    <strong>1</strong>
+    <a href="search.php?mod=forum&amp;searchid=98765&amp;orderby=lastpost&amp;ascdesc=desc&amp;searchsubmit=yes&amp;page=2">2</a>
+    <a href="search.php?mod=forum&amp;searchid=98765&amp;orderby=lastpost&amp;ascdesc=desc&amp;searchsubmit=yes&amp;page=3">3</a>
+    <label>
+      <span title="共 7 页"> / 7 页</span>
+    </label>
+    <a href="search.php?mod=forum&amp;searchid=98765&amp;orderby=lastpost&amp;ascdesc=desc&amp;searchsubmit=yes&amp;page=2" class="nxt">下一页</a>
+  </div>
+</div>
+</body>
+</html>

--- a/test/fixtures/search_forum_empty.html
+++ b/test/fixtures/search_forum_empty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><title>搜索 - Stage1st</title></head>
+<body>
+<div id="ct" class="wp cl">
+  <h1 class="xs2"><em>找到 “zzzznotfoundzzz” 相关内容 0 个</em></h1>
+</div>
+</body>
+</html>

--- a/test/fixtures/search_rate_limited.html
+++ b/test/fixtures/search_rate_limited.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><title>提示信息 - Stage1st</title></head>
+<body>
+<div id="messagetext" class="alert_error">
+  <p>抱歉，您在 30 秒内只能进行一次搜索</p>
+</div>
+</body>
+</html>

--- a/test/fixtures/search_user.html
+++ b/test/fixtures/search_user.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><title>搜索用户 - Stage1st</title></head>
+<body>
+<div id="ct" class="wp cl">
+  <div class="bm">
+    <ul class="mtw xld xlda">
+      <li class="bbda cl">
+        <div class="avt"><a href="home.php?mod=space&amp;uid=10001"><img src="https://avatar.stage1st.com/avatar.php?uid=10001&amp;size=small" alt="" /></a></div>
+        <div>
+          <a href="home.php?mod=space&amp;uid=10001" class="xi2">demo_user</a>
+          <p>积分: 100</p>
+        </div>
+      </li>
+      <li class="bbda cl">
+        <div class="avt"><a href="space-uid-42.html"><img alt="" /></a></div>
+        <div>
+          <a href="space-uid-42.html">demo_user_fan</a>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -100,7 +100,8 @@ void main() {
 
     await tester.tap(find.text('搜索'));
     await tester.pumpAndSettle();
-    expect(find.text('搜索'), findsNWidgets(2));
+    expect(find.text('搜索'), findsOneWidget);
+    expect(find.text('搜索主题与帖子'), findsOneWidget);
     expect(find.text('Search'), findsNothing);
 
     await tester.tap(find.text('消息'));

--- a/test/screens/search_screen_test.dart
+++ b/test/screens/search_screen_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/search_result.dart';
+import 'package:s1_app/providers/search_provider.dart';
+import 'package:s1_app/screens/search_screen.dart';
+import 'package:s1_app/theme/app_theme.dart';
+
+class _SeededSearchNotifier extends SearchNotifier {
+  @override
+  SearchUiState build() => const SearchUiState(
+        hasSearched: true,
+        query: 'switch',
+        forumHits: [
+          ForumSearchHit(
+            tid: '100',
+            title: '假帖 switch',
+            snippet: '摘要',
+            forumName: '游戏论坛',
+            author: 'alice',
+            dateline: '2026-7-1',
+          ),
+        ],
+        count: 1,
+      );
+}
+
+void main() {
+  testWidgets('SearchScreen idle shows type hint', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const Scaffold(body: SearchScreen()),
+        ),
+      ),
+    );
+
+    expect(find.text('搜索主题与帖子'), findsOneWidget);
+    expect(find.text('主题'), findsOneWidget);
+    expect(find.text('用户'), findsOneWidget);
+  });
+
+  testWidgets('SearchScreen shows seeded forum hits', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          searchProvider.overrideWith(_SeededSearchNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const Scaffold(body: SearchScreen()),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    expect(find.text('假帖 switch'), findsOneWidget);
+    expect(find.textContaining('找到 1 条'), findsOneWidget);
+    expect(find.textContaining('游戏论坛'), findsOneWidget);
+  });
+}

--- a/test/services/search_parser_test.dart
+++ b/test/services/search_parser_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/services/api_service.dart';
+
+void main() {
+  group('parseForumSearchHtml', () {
+    test('parses hits, count and pagination', () {
+      final html = File('test/fixtures/search_forum.html').readAsStringSync();
+      final page = ApiService.parseForumSearchHtml(html);
+
+      expect(page.error, isNull);
+      expect(page.count, 128);
+      expect(page.currentPage, 1);
+      expect(page.totalPages, 7);
+      expect(page.pageHref, contains('page='));
+      expect(page.pageHref, isNot(contains('page=2')));
+      expect(page.hits, hasLength(2));
+
+      final first = page.hits.first;
+      expect(first.tid, '2265001');
+      expect(first.title, contains('Switch 2'));
+      expect(first.snippet, contains('switch'));
+      expect(first.forumName, '游戏论坛');
+      expect(first.author, 'alice');
+      expect(first.dateline, contains('2026'));
+
+      expect(page.hits[1].tid, '2201002');
+      expect(page.hits[1].author, 'bob');
+    });
+
+    test('parses empty result count', () {
+      final html =
+          File('test/fixtures/search_forum_empty.html').readAsStringSync();
+      final page = ApiService.parseForumSearchHtml(html);
+      expect(page.hits, isEmpty);
+      expect(page.count, 0);
+      expect(page.error, isNull);
+    });
+
+    test('surfaces rate-limit messagetext as error', () {
+      final html =
+          File('test/fixtures/search_rate_limited.html').readAsStringSync();
+      final page = ApiService.parseForumSearchHtml(html);
+      expect(page.hasError, isTrue);
+      expect(page.error, contains('30 秒'));
+      expect(page.hits, isEmpty);
+    });
+
+    test('throws LoginRequiredException for login form HTML', () {
+      const html = '<form id="loginform_" name="login"></form>';
+      expect(
+        () => ApiService.parseForumSearchHtml(html),
+        throwsA(isA<LoginRequiredException>()),
+      );
+    });
+  });
+
+  group('parseUserSearchHtml', () {
+    test('parses uid and name from bbda list', () {
+      final html = File('test/fixtures/search_user.html').readAsStringSync();
+      final page = ApiService.parseUserSearchHtml(html);
+
+      expect(page.error, isNull);
+      expect(page.hits, hasLength(2));
+      expect(page.hits[0].uid, '10001');
+      expect(page.hits[0].name, 'demo_user');
+      expect(page.hits[1].uid, '42');
+      expect(page.hits[1].name, 'demo_user_fan');
+    });
+
+    test('surfaces messagetext error', () {
+      final html =
+          File('test/fixtures/search_rate_limited.html').readAsStringSync();
+      final page = ApiService.parseUserSearchHtml(html);
+      expect(page.hasError, isTrue);
+      expect(page.error, contains('搜索'));
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

落地搜索 MVP（对齐 S1-Next `search.php`），替换登录态「搜索」Tab 占位。

### 功能
- **主题搜索** `POST search.php?mod=forum`：结构化解析 `li.pbw`，分页 `div.pg` / `pageHref` GET 翻页
- **用户搜索** `POST search.php?mod=user`：解析 `li.bbda` → 资料 sheet
- **冷却**：提交后 30s，降低 `allowsearch` 限流连点
- 空结果 / `#messagetext` 限流文案 / 需登录 有提示

### 主要改动
- `ApiService.searchForum` / `searchUser` + HTML 解析
- `SearchScreen` + `searchProvider`
- fixtures + parser / widget 单测
- 更新 `api_reference.md` 与 gap 报告（搜索 → 已实现）

### 备注
Spike 直播抓包时论坛返回过载（`姨妈一会，太卡了`），fixture 按 S1-Next 选择器手写；待服务器恢复后建议手动冒烟一次。

### 测试
- ✅ `flutter test` 相关：`search_parser` / `search_screen` / `api_config` / `home_screen`
- ✅ 改动文件 `flutter analyze` 无 issue
- ✅ M3 audit `--fail-on-error`
- 全量 `flutter test`：511+；仅既有 `guardrails_test`（`compose_screen` 直引 `external_image_upload_service`）失败，与本 PR 无关

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f607b-150b-7cb8-8223-ffb8a4fbb76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f607b-150b-7cb8-8223-ffb8a4fbb76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

