### PR TITLE
refactor(nav): 帖子导航契约重构与楼级续读

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,10 +21,10 @@ import 'screens/favorites_screen.dart';
 import 'screens/image_viewer_screen.dart';
 import 'screens/user_space_screen.dart';
 import 'screens/pm_conversation_screen.dart';
-import 'models/thread_open_intent.dart';
 import 'providers/thread_open_intent_provider.dart';
 import 'services/talker.dart';
 import 'theme/app_theme.dart';
+import 'utils/thread_navigation.dart';
 
 ImageViewerScreen? _parseImageViewerRoute(GoRouterState state) {
   Map<String, dynamic>? args;
@@ -72,23 +72,17 @@ final _router = GoRouter(
     ),
     GoRoute(
       path: '/thread/:tid',
-      builder: (context, state) {
+      // Key only by tid so in-thread `?page=` replace syncs URL without remount.
+      pageBuilder: (context, state) {
         final tid = state.pathParameters['tid']!;
-        final pageStr = state.uri.queryParameters['page'];
-        final page = pageStr != null ? int.tryParse(pageStr) : null;
-        final pid = state.uri.queryParameters['pid'];
-        final intent = (page != null || pid != null)
-            ? ThreadOpenIntent(initialPage: page, targetPid: pid)
-            : null;
-        return ProviderScope(
-          overrides: [
-            if (intent != null)
+        final intent = ThreadRouteCodec.intentFromUri(state.uri, tid: tid);
+        return NoTransitionPage<void>(
+          key: ValueKey('thread-$tid'),
+          child: ProviderScope(
+            overrides: [
               threadOpenIntentProvider(tid).overrideWithValue(intent),
-          ],
-          child: ThreadDetailScreen(
-            tid: tid,
-            initialPage: page,
-            targetPid: pid,
+            ],
+            child: ThreadDetailScreen(tid: tid),
           ),
         );
       },

--- a/lib/models/open_scroll_target.dart
+++ b/lib/models/open_scroll_target.dart
@@ -1,0 +1,24 @@
+/// 帖子详情首屏一次性滚动落点（由 [PostListState] 携带，Screen 消费一次）。
+sealed class OpenScrollTarget {
+  const OpenScrollTarget();
+}
+
+/// 滚到指定 pid；[highlight] 为 true 时高亮该楼。
+final class ScrollToPid extends OpenScrollTarget {
+  const ScrollToPid(this.pid, {this.highlight = true});
+
+  final String pid;
+  final bool highlight;
+}
+
+/// 滚到绝对楼层（1-based，跨页累计）；用于 resume 楼级落点。
+final class ScrollToFloor extends OpenScrollTarget {
+  const ScrollToFloor(this.absoluteFloor);
+
+  final int absoluteFloor;
+}
+
+/// 落到当前页顶部（强制页 / B3 新页）。
+final class ScrollToPageTop extends OpenScrollTarget {
+  const ScrollToPageTop();
+}

--- a/lib/models/reading_record.dart
+++ b/lib/models/reading_record.dart
@@ -42,7 +42,7 @@ class ReadingRecord {
   /// 最后阅读页码（1-based）
   final int lastReadPage;
 
-  /// 最后阅读的绝对楼层（1-based，跨页累计）；仅用于展示，不参与判定。
+  /// 最后阅读的绝对楼层（1-based，跨页累计）；resume 时用于楼级落点。
   final int lastReadFloor;
 
   /// 帖子总页数（缓存）

--- a/lib/models/thread_destination.dart
+++ b/lib/models/thread_destination.dart
@@ -1,0 +1,26 @@
+/// 帖子详情打开目标（纯 Dart；与 URL 一一对应）。
+sealed class ThreadDestination {
+  const ThreadDestination(this.tid);
+
+  final String tid;
+}
+
+/// 按本地阅读记录续读（页 + 楼级落点）；URI 为裸 `/thread/{tid}`。
+final class ResumeThread extends ThreadDestination {
+  const ResumeThread(super.tid);
+}
+
+/// 强制打开指定页（含 page=1），覆盖续读；落到页顶。
+final class ThreadPage extends ThreadDestination {
+  const ThreadPage(super.tid, this.page)
+      : assert(page >= 1, 'page must be >= 1');
+
+  final int page;
+}
+
+/// 定位到指定回复 pid 并高亮。
+final class ThreadPost extends ThreadDestination {
+  const ThreadPost(super.tid, this.pid);
+
+  final String pid;
+}

--- a/lib/models/thread_open_intent.dart
+++ b/lib/models/thread_open_intent.dart
@@ -1,16 +1,48 @@
-/// 帖子详情页一次性打开意图（由路由或入口注入，仅首屏 [PostNotifier.build] 消费）。
+/// 帖子详情打开模式（由路由解码或入口注入）。
+enum ThreadOpenMode {
+  /// 按本地阅读记录续读（可附带预解析 page 提示，仍为续读）。
+  resume,
+
+  /// 强制指定页，覆盖续读。
+  page,
+
+  /// 按 pid 定位楼层。
+  post,
+}
+
+/// 帖子详情页一次性打开意图（由路由注入，仅首屏 [PostNotifier.build] 消费）。
 class ThreadOpenIntent {
   const ThreadOpenIntent({
-    this.initialPage,
-    this.targetPid,
+    required this.mode,
+    this.page,
+    this.pid,
     this.liveTotalPages,
   });
 
-  /// 显式目标页（来自 `?page=` 或入口预解析）。
-  final int? initialPage;
+  /// 裸 `/thread/{tid}` 或带 `resume=1` 的续读。
+  const ThreadOpenIntent.resume({
+    this.page,
+    this.liveTotalPages,
+  })  : mode = ThreadOpenMode.resume,
+        pid = null;
 
-  /// 目标楼层 pid（来自 `?pid=`）。
-  final String? targetPid;
+  /// 强制 `?page=`（含 page=1）。
+  const ThreadOpenIntent.page(this.page, {this.liveTotalPages})
+      : mode = ThreadOpenMode.page,
+        pid = null;
+
+  /// `?pid=` 定位。
+  const ThreadOpenIntent.post(this.pid, {this.liveTotalPages})
+      : mode = ThreadOpenMode.post,
+        page = null;
+
+  final ThreadOpenMode mode;
+
+  /// 强制页，或 resume 预解析提示页（仍须再跑 B1–B3 / 楼级）。
+  final int? page;
+
+  /// 目标楼层 pid。
+  final String? pid;
 
   /// 入口已知的实时总页数（如列表 `thread.replies` 推算），用于续读 B3 判定。
   final int? liveTotalPages;

--- a/lib/providers/post_provider.dart
+++ b/lib/providers/post_provider.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../config/constants.dart';
+import '../models/open_scroll_target.dart';
 import '../models/post.dart';
 import '../models/poll.dart';
+import '../models/thread_open_intent.dart';
 import '../services/api_service.dart';
 import '../services/http_client.dart';
 import '../services/poll_vote_cache.dart';
@@ -28,6 +30,8 @@ class PostListState {
     this.filterAuthorId,
     this.filterAuthorName,
     this.allowReply = true,
+    this.openScrollTarget,
+    this.locateError,
   });
 
   final List<Post> posts;
@@ -41,6 +45,12 @@ class PostListState {
   final String? filterAuthorId;
   final String? filterAuthorName;
   final bool allowReply;
+
+  /// 首屏一次性滚动落点；Screen 消费后应通过 [clearOpenScrollTarget] 清除。
+  final OpenScrollTarget? openScrollTarget;
+
+  /// pid 定位失败时的用户可读说明（加载仍可能落到某一页）。
+  final String? locateError;
 
   bool get isFiltering => filterAuthorId != null;
 
@@ -57,6 +67,10 @@ class PostListState {
     String? filterAuthorName,
     bool clearFilter = false,
     bool? allowReply,
+    OpenScrollTarget? openScrollTarget,
+    bool clearOpenScrollTarget = false,
+    String? locateError,
+    bool clearLocateError = false,
   }) {
     return PostListState(
       posts: posts ?? this.posts,
@@ -72,6 +86,11 @@ class PostListState {
       filterAuthorName:
           clearFilter ? null : (filterAuthorName ?? this.filterAuthorName),
       allowReply: allowReply ?? this.allowReply,
+      openScrollTarget: clearOpenScrollTarget
+          ? null
+          : (openScrollTarget ?? this.openScrollTarget),
+      locateError:
+          clearLocateError ? null : (locateError ?? this.locateError),
     );
   }
 }
@@ -98,20 +117,68 @@ class PostNotifier extends AsyncNotifier<PostListState> {
   @override
   Future<PostListState> build() async {
     final intent = ref.read(threadOpenIntentProvider(tid));
+    final mode = intent?.mode ?? ThreadOpenMode.resume;
 
-    if (intent?.targetPid != null && intent!.targetPid!.isNotEmpty) {
-      final page = await _apiService.locatePostPage(tid, intent.targetPid!);
-      return _loadPage(page);
+    if (mode == ThreadOpenMode.post) {
+      final pid = intent?.pid;
+      if (pid != null && pid.isNotEmpty) {
+        return _openByPid(pid);
+      }
     }
 
-    final explicitPage = intent?.initialPage;
-    if (explicitPage != null && explicitPage > 1) {
-      return _loadPage(explicitPage);
+    if (mode == ThreadOpenMode.page) {
+      final page = resolveThreadInitialPage(intent: intent, record: null);
+      final loaded = await _loadPage(page);
+      return loaded.copyWith(openScrollTarget: const ScrollToPageTop());
     }
 
+    // resume
     final record = ref.read(readingRecordProvider(tid));
-    final page = resolveThreadInitialPage(intent: intent, record: record);
-    return _loadPage(page);
+    var page = resolveThreadInitialPage(intent: intent, record: record);
+    var loaded = await _loadPage(page);
+
+    // B3：在首屏暴露前用 API 总页数再校正
+    if (record != null &&
+        record.isFinished &&
+        record.hasNewPages(loaded.totalPages)) {
+      final targetPage =
+          (record.totalPages + 1).clamp(1, loaded.totalPages);
+      if (loaded.currentPage < targetPage) {
+        loaded = await _loadPage(targetPage);
+        return loaded.copyWith(openScrollTarget: const ScrollToPageTop());
+      }
+    }
+
+    final scrollTarget = resolveResumeScrollTarget(
+      record: record,
+      loadedPage: loaded.currentPage,
+      totalPages: loaded.totalPages,
+    );
+    return loaded.copyWith(openScrollTarget: scrollTarget);
+  }
+
+  Future<PostListState> _openByPid(String pid) async {
+    try {
+      final page = await _apiService.locatePostPage(tid, pid);
+      final loaded = await _loadPage(page);
+      final found = loaded.posts.any((p) => p.pid == pid);
+      if (!found) {
+        return loaded.copyWith(
+          openScrollTarget: const ScrollToPageTop(),
+          locateError: '未找到目标楼层',
+        );
+      }
+      return loaded.copyWith(
+        openScrollTarget: ScrollToPid(pid),
+        clearLocateError: true,
+      );
+    } catch (e) {
+      final loaded = await _loadPage(1);
+      return loaded.copyWith(
+        openScrollTarget: const ScrollToPageTop(),
+        locateError: '定位楼层失败',
+      );
+    }
   }
 
   ThreadPoll? _pollWithUserVotes(
@@ -170,16 +237,27 @@ class PostNotifier extends AsyncNotifier<PostListState> {
 
   Future<void> locatePid(String pid) async {
     state = const AsyncValue.loading();
-    final page = await _apiService.locatePostPage(tid, pid);
-    state = await AsyncValue.guard(() => _loadPage(page));
+    state = await AsyncValue.guard(() => _openByPid(pid));
   }
 
   Future<void> goToPage(int page) async {
     final previous = state.asData?.value;
-    state = await AsyncValue.guard(() => _loadPage(page));
+    state = await AsyncValue.guard(() async {
+      final loaded = await _loadPage(page);
+      return loaded.copyWith(
+        openScrollTarget: const ScrollToPageTop(),
+        clearLocateError: true,
+      );
+    });
     if (state.hasError && previous != null) {
       state = AsyncValue.data(previous);
     }
+  }
+
+  void clearOpenScrollTarget() {
+    final current = state.asData?.value;
+    if (current == null || current.openScrollTarget == null) return;
+    state = AsyncValue.data(current.copyWith(clearOpenScrollTarget: true));
   }
 
   Future<void> filterByAuthor(String authorId, String authorName) async {

--- a/lib/providers/post_provider.dart
+++ b/lib/providers/post_provider.dart
@@ -173,6 +173,7 @@ class PostNotifier extends AsyncNotifier<PostListState> {
         clearLocateError: true,
       );
     } catch (e) {
+      if (!ref.mounted) rethrow;
       final loaded = await _loadPage(1);
       return loaded.copyWith(
         openScrollTarget: const ScrollToPageTop(),

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -3,12 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../config/api_config.dart';
 import '../models/favorite_item.dart';
+import '../models/thread_destination.dart';
 import '../providers/auth_provider.dart';
 import '../providers/favorite_list_provider.dart';
 import '../providers/favorite_membership_provider.dart';
 import '../widgets/favorite_confirm_dialog.dart';
 import '../utils/format_utils.dart';
 import '../utils/s1_snack_bar.dart';
+import '../utils/thread_navigation.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/pagination_bar.dart';
 import '../widgets/s1_error_view.dart';
@@ -260,7 +262,9 @@ class _FavoriteThreadTile extends StatelessWidget {
       elevation: 0,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       child: InkWell(
-        onTap: () => context.push('/thread/${item.id}'),
+        onTap: () => context.push(
+              ThreadRouteCodec.encodePath(ResumeThread(item.id)),
+            ),
         child: Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
           child: Row(

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../models/notice_item.dart';
+import '../models/thread_destination.dart';
 import '../providers/messages_segment_provider.dart';
 import '../providers/notice_list_provider.dart';
 import '../providers/pm_list_provider.dart';
 import '../theme/app_theme.dart';
+import '../utils/thread_navigation.dart';
 import '../widgets/notice_list_tile.dart';
 import '../widgets/pagination_bar.dart';
 import '../widgets/pm_list_tile.dart';
@@ -183,11 +185,13 @@ class _NoticeListBody extends ConsumerWidget {
                               onTap: () {
                                 if (!item.canNavigate) return;
                                 final pid = item.pid;
-                                if (pid != null && pid.isNotEmpty) {
-                                  context.push('/thread/${item.tid}?pid=$pid');
-                                } else {
-                                  context.push('/thread/${item.tid}');
-                                }
+                                final destination =
+                                    pid != null && pid.isNotEmpty
+                                        ? ThreadPost(item.tid, pid)
+                                        : ResumeThread(item.tid);
+                                context.push(
+                                  ThreadRouteCodec.encodePath(destination),
+                                );
                               },
                             ),
                           );

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -3,10 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../models/search_result.dart';
+import '../models/thread_destination.dart';
 import '../models/user.dart';
 import '../providers/search_provider.dart';
 import '../providers/user_profile_provider.dart';
 import '../theme/app_theme.dart';
+import '../utils/thread_navigation.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/pagination_bar.dart';
 import '../widgets/user_profile_sheet.dart';
@@ -353,7 +355,9 @@ class _ForumHitTile extends StatelessWidget {
         ],
       ),
       isThreeLine: hit.snippet.isNotEmpty,
-      onTap: () => context.push('/thread/${hit.tid}'),
+      onTap: () => context.push(
+            ThreadRouteCodec.encodePath(ResumeThread(hit.tid)),
+          ),
     );
   }
 }

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -121,9 +121,9 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     if (!shouldRecordReadingProgress(settings, auth)) {
       return;
     }
-    final resolvedFloor = floorInPage ??
-        (_lastRecordedFloorInPage ??
-            (state.posts.isEmpty ? 1 : state.posts.length));
+    // Prefer the caller-provided / last visible floor. Never fall back to
+    // `posts.length` (that permanently wrote "page end" as fake progress).
+    final resolvedFloor = floorInPage ?? _lastRecordedFloorInPage ?? 1;
     if (!shouldWriteReadingProgressUpdate(
       hasRecordedInitialVisit: _hasRecordedInitialVisit,
       lastRecordedPage: _lastRecordedPage,
@@ -176,15 +176,25 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     if (target == null) return;
 
     _pendingInitialNavigation = true;
-    if (mounted) setState(() {});
+    if (_postKeys.length != state.posts.length) {
+      setState(() {
+        _postKeys = List.generate(state.posts.length, (_) => GlobalKey());
+      });
+    } else if (mounted) {
+      setState(() {});
+    }
+    await WidgetsBinding.instance.endOfFrame;
 
     final ok = await _applyOpenScrollTarget(state, target);
     if (!mounted) return;
 
     if (ok) {
       _openScrollConsumed = true;
+      // Clear the progress gate before notifying listeners (clearOpenScrollTarget).
+      _pendingInitialNavigation = false;
+      if (mounted) setState(() {});
       ref.read(postProvider(widget.tid).notifier).clearOpenScrollTarget();
-      setState(() => _pendingInitialNavigation = false);
+      _maybeRecordVisibleFloor(state);
     } else {
       // 懒列表尚未构建目标楼：短暂等待后重试。
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -338,6 +348,11 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     context.replace(
       ThreadRouteCodec.encodePath(ThreadPage(widget.tid, page)),
     );
+    final loaded = ref.read(postProvider(widget.tid)).asData?.value;
+    if (loaded != null) {
+      // Page changes land at top; keys rebuild after the next frame.
+      _recordProgress(loaded, floorInPage: 1);
+    }
   }
 
   bool _showsPollOnPage(PostListState state) =>
@@ -576,8 +591,8 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         _maybeShowLocateError(state);
         if (!_openScrollConsumed && state.openScrollTarget != null) {
           unawaited(_consumeOpenScrollTarget(state));
-        } else {
-          _recordProgress(state);
+        } else if (!_pendingInitialNavigation) {
+          _maybeRecordVisibleFloor(state);
         }
       });
     });
@@ -615,148 +630,143 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
           ),
         ],
       ),
-      body: _pendingInitialNavigation
-          ? _buildLoadingBody()
-          : postsAsync.when(
-              loading: _buildLoadingBody,
-              error: (e, st) => S1ErrorView(
-                error: e,
-                onRetry: () =>
-                    ref.read(postProvider(widget.tid).notifier).refresh(),
-                onLogin: () => context.push('/login'),
-              ),
-              data: (state) {
-                _scheduleEnsurePostKeys(state.posts.length);
-                final showPrimary = isLoggedIn && state.allowReply;
-                final hasNextPage = state.currentPage < state.totalPages;
-                final scheme = Theme.of(context).colorScheme;
+      // Keep the post list mounted while consuming OpenScrollTarget so
+      // index-based scroll (pid / floor) can run against live GlobalKeys.
+      // `_pendingInitialNavigation` only gates progress writeback.
+      body: postsAsync.when(
+        loading: _buildLoadingBody,
+        error: (e, st) => S1ErrorView(
+          error: e,
+          onRetry: () => ref.read(postProvider(widget.tid).notifier).refresh(),
+          onLogin: () => context.push('/login'),
+        ),
+        data: (state) {
+          _scheduleEnsurePostKeys(state.posts.length);
+          final showPrimary = isLoggedIn && state.allowReply;
+          final hasNextPage = state.currentPage < state.totalPages;
+          final scheme = Theme.of(context).colorScheme;
 
-                return Column(
-                  children: [
-                    if (state.isFiltering)
-                      Container(
-                        width: double.infinity,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 10,
-                        ),
-                        color: scheme.primaryContainer,
-                        child: Row(
-                          children: [
-                            Icon(
-                              Icons.filter_alt,
-                              size: 18,
-                              color: scheme.onPrimaryContainer,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                '只看「${state.filterAuthorName}」的帖子',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodyMedium
-                                    ?.copyWith(
-                                      color: scheme.onPrimaryContainer,
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                              ),
-                            ),
-                            TextButton.icon(
-                              onPressed: () => ref
-                                  .read(postProvider(widget.tid).notifier)
-                                  .clearFilter(),
-                              icon: Icon(
-                                Icons.close,
-                                size: 18,
-                                color: scheme.onPrimaryContainer,
-                              ),
-                              label: Text(
-                                '取消',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .labelLarge
-                                    ?.copyWith(
-                                      color: scheme.onPrimaryContainer,
-                                    ),
-                              ),
-                            ),
-                          ],
-                        ),
+          return Column(
+            children: [
+              if (state.isFiltering)
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 10,
+                  ),
+                  color: scheme.primaryContainer,
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.filter_alt,
+                        size: 18,
+                        color: scheme.onPrimaryContainer,
                       ),
-                    Expanded(
-                      child: S1ContentFabOverlay(
-                        fab: ValueListenableBuilder<_ScrollFabVisibility>(
-                          valueListenable: _scrollFabVisibility,
-                          builder: (context, fab, _) {
-                            final showScrollAdvance = fab.showScrollDown ||
-                                (fab.atPageBottom && hasNextPage);
-                            final advanceMode = fab.atPageBottom && hasNextPage
-                                ? ScrollNavAdvanceMode.nextPage
-                                : ScrollNavAdvanceMode.nextFloor;
-                            return S1FabStack(
-                              scrollNav: S1ScrollNavConfig(
-                                showScrollToTop: fab.showScrollToTop,
-                                showScrollAdvance: showScrollAdvance,
-                                advanceMode: advanceMode,
-                                onScrollToTop: _scrollToTop,
-                                onScrollToNextFloor: _scrollToNextFloor,
-                                onScrollToBottom: _scrollToBottom,
-                                onGoToNextPage: hasNextPage
-                                    ? () => _goToPage(state.currentPage + 1)
-                                    : null,
-                              ),
-                              primary: showPrimary
-                                  ? S1FabItem(
-                                      heroTag: 'replyDetail',
-                                      icon: Icons.edit_outlined,
-                                      tooltip: '回复',
-                                      onPressed: () => _openCompose(state),
-                                    )
-                                  : null,
-                            );
-                          },
-                        ),
-                        child: S1SwipePagination(
-                          key: _swipeKey,
-                          currentPage: state.currentPage,
-                          totalPages: state.totalPages,
-                          onScrollMetricsChanged: _onScrollMetricsChanged,
-                          onPageChanged: _goToPage,
-                          pageBuilder: (context, scrollController) => Scrollbar(
-                            controller: scrollController,
-                            child: state.posts.isEmpty
-                                ? const Center(child: Text('暂无回复'))
-                                : ListView.builder(
-                                    controller: scrollController,
-                                    padding: S1FabLayout
-                                        .threadDetailScrollBottomPadding,
-                                    itemCount: _detailItemCount(state),
-                                    itemBuilder: (context, index) =>
-                                        _buildDetailItem(
-                                      context,
-                                      state,
-                                      index,
-                                    ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          '只看「${state.filterAuthorName}」的帖子',
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: scheme.onPrimaryContainer,
+                                    fontWeight: FontWeight.w500,
                                   ),
-                          ),
                         ),
                       ),
+                      TextButton.icon(
+                        onPressed: () => ref
+                            .read(postProvider(widget.tid).notifier)
+                            .clearFilter(),
+                        icon: Icon(
+                          Icons.close,
+                          size: 18,
+                          color: scheme.onPrimaryContainer,
+                        ),
+                        label: Text(
+                          '取消',
+                          style:
+                              Theme.of(context).textTheme.labelLarge?.copyWith(
+                                    color: scheme.onPrimaryContainer,
+                                  ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Expanded(
+                child: S1ContentFabOverlay(
+                  fab: ValueListenableBuilder<_ScrollFabVisibility>(
+                    valueListenable: _scrollFabVisibility,
+                    builder: (context, fab, _) {
+                      final showScrollAdvance = fab.showScrollDown ||
+                          (fab.atPageBottom && hasNextPage);
+                      final advanceMode = fab.atPageBottom && hasNextPage
+                          ? ScrollNavAdvanceMode.nextPage
+                          : ScrollNavAdvanceMode.nextFloor;
+                      return S1FabStack(
+                        scrollNav: S1ScrollNavConfig(
+                          showScrollToTop: fab.showScrollToTop,
+                          showScrollAdvance: showScrollAdvance,
+                          advanceMode: advanceMode,
+                          onScrollToTop: _scrollToTop,
+                          onScrollToNextFloor: _scrollToNextFloor,
+                          onScrollToBottom: _scrollToBottom,
+                          onGoToNextPage: hasNextPage
+                              ? () => _goToPage(state.currentPage + 1)
+                              : null,
+                        ),
+                        primary: showPrimary
+                            ? S1FabItem(
+                                heroTag: 'replyDetail',
+                                icon: Icons.edit_outlined,
+                                tooltip: '回复',
+                                onPressed: () => _openCompose(state),
+                              )
+                            : null,
+                      );
+                    },
+                  ),
+                  child: S1SwipePagination(
+                    key: _swipeKey,
+                    currentPage: state.currentPage,
+                    totalPages: state.totalPages,
+                    onScrollMetricsChanged: _onScrollMetricsChanged,
+                    onPageChanged: _goToPage,
+                    pageBuilder: (context, scrollController) => Scrollbar(
+                      controller: scrollController,
+                      child: state.posts.isEmpty
+                          ? const Center(child: Text('暂无回复'))
+                          : ListView.builder(
+                              controller: scrollController,
+                              padding:
+                                  S1FabLayout.threadDetailScrollBottomPadding,
+                              itemCount: _detailItemCount(state),
+                              itemBuilder: (context, index) => _buildDetailItem(
+                                context,
+                                state,
+                                index,
+                              ),
+                            ),
                     ),
-                    PaginationBar(
-                      currentPage: state.currentPage,
-                      totalPages: state.totalPages,
-                      sheetSubtitle: state.threadSubject,
-                      pageItemLabelBuilder: (page) {
-                        final start = (page - 1) * state.perPage + 1;
-                        final end = page * state.perPage;
-                        return '第 $start - $end 楼';
-                      },
-                      onPageChanged: _goToPage,
-                    ),
-                  ],
-                );
-              },
-            ),
+                  ),
+                ),
+              ),
+              PaginationBar(
+                currentPage: state.currentPage,
+                totalPages: state.totalPages,
+                sheetSubtitle: state.threadSubject,
+                pageItemLabelBuilder: (page) {
+                  final start = (page - 1) * state.perPage + 1;
+                  final end = page * state.perPage;
+                  return '第 $start - $end 楼';
+                },
+                onPageChanged: _goToPage,
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -24,8 +24,11 @@ import '../widgets/s1_confirm_dialog.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/s1_fab_layout.dart';
 import '../widgets/s1_swipe_pagination.dart';
+import '../models/open_scroll_target.dart';
+import '../models/thread_destination.dart';
 import '../utils/scroll_floor.dart';
 import '../utils/s1_snack_bar.dart';
+import '../utils/thread_navigation.dart';
 import '../theme/app_theme.dart';
 
 bool shouldRecordReadingProgress(AppSettings settings, AuthState auth) {
@@ -38,14 +41,17 @@ bool shouldRecordReadingProgress(AppSettings settings, AuthState auth) {
   return true;
 }
 
-/// 仅在首访或翻页时写库；同页非进度更新（如评分日志合并）跳过。
+/// 仅在首访、翻页或页内可见楼变化时写库。
 bool shouldWriteReadingProgressUpdate({
   required bool hasRecordedInitialVisit,
   required int? lastRecordedPage,
+  required int? lastRecordedFloorInPage,
   required int currentPage,
+  required int currentFloorInPage,
 }) {
   if (!hasRecordedInitialVisit) return true;
-  return lastRecordedPage != currentPage;
+  if (lastRecordedPage != currentPage) return true;
+  return lastRecordedFloorInPage != currentFloorInPage;
 }
 
 /// 滚动 FAB 显隐状态（用 [ValueNotifier] 更新，避免重建列表）。
@@ -65,12 +71,8 @@ class ThreadDetailScreen extends ConsumerStatefulWidget {
   const ThreadDetailScreen({
     super.key,
     required this.tid,
-    this.initialPage,
-    this.targetPid,
   });
   final String tid;
-  final int? initialPage;
-  final String? targetPid;
 
   @override
   ConsumerState<ThreadDetailScreen> createState() => _ThreadDetailScreenState();
@@ -79,14 +81,15 @@ class ThreadDetailScreen extends ConsumerStatefulWidget {
 class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   final _swipeKey = GlobalKey<S1SwipePaginationState>();
   final _scrollFabVisibility = ValueNotifier(const _ScrollFabVisibility());
-  String? _scrollOncePid;
   bool _hasRecordedInitialVisit = false;
   int? _lastRecordedPage;
+  int? _lastRecordedFloorInPage;
   bool _pendingInitialNavigation = false;
-  bool _b3CorrectionDone = false;
+  bool _openScrollConsumed = false;
   String? _highlightPid;
+  String? _shownLocateError;
 
-  /// 用户手动翻页后为 true，此时不再对 targetPid / highlight 做 ensureVisible。
+  /// 用户手动翻页后为 true，此时不再消费 openScrollTarget。
   bool _manualPageChange = false;
 
   /// 当前页各楼 PostItem 的 key（不含 PollCard），翻页时重建。
@@ -98,6 +101,9 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
   /// 防止连点叠加滚动动画。
   bool _scrollAnimating = false;
 
+  /// 楼级进度回写节流。
+  DateTime? _lastFloorProgressAt;
+
   @override
   void dispose() {
     _scrollFabVisibility.dispose();
@@ -106,7 +112,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
 
   /// 记录阅读进度：写库 + 刷新历史列表（使列表卡片/历史页/资料计数实时更新）。
   /// readCount 只在本次进入详情页首帧 +1（isNewVisit 由 _hasRecordedInitialVisit 守卫）。
-  void _recordProgress(PostListState state) {
+  void _recordProgress(PostListState state, {int? floorInPage}) {
     if (_pendingInitialNavigation) {
       return;
     }
@@ -115,17 +121,22 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     if (!shouldRecordReadingProgress(settings, auth)) {
       return;
     }
+    final resolvedFloor = floorInPage ??
+        (_lastRecordedFloorInPage ??
+            (state.posts.isEmpty ? 1 : state.posts.length));
     if (!shouldWriteReadingProgressUpdate(
       hasRecordedInitialVisit: _hasRecordedInitialVisit,
       lastRecordedPage: _lastRecordedPage,
+      lastRecordedFloorInPage: _lastRecordedFloorInPage,
       currentPage: state.currentPage,
+      currentFloorInPage: resolvedFloor,
     )) {
       return;
     }
     ref.read(readingHistoryServiceProvider).updateProgress(
           tid: widget.tid,
           page: state.currentPage,
-          floorInPage: state.posts.length,
+          floorInPage: resolvedFloor,
           subject: state.threadSubject ?? '',
           author: state.posts.isNotEmpty ? state.posts.first.author : '',
           fid: state.threadFid ?? '',
@@ -136,6 +147,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         );
     _hasRecordedInitialVisit = true;
     _lastRecordedPage = state.currentPage;
+    _lastRecordedFloorInPage = resolvedFloor;
     final record =
         ref.read(readingHistoryServiceProvider).getRecord(widget.tid);
     if (record != null) {
@@ -143,35 +155,91 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     }
   }
 
-  /// B3 边缘：无 URL 参数且本地 record 落后于 API 总页数时，静默跳到新回复页。
-  void _maybeCorrectNewReplyPage(PostListState state) {
-    if (_b3CorrectionDone) return;
-    _b3CorrectionDone = true;
+  void _maybeRecordVisibleFloor(PostListState state) {
+    final now = DateTime.now();
+    if (_lastFloorProgressAt != null &&
+        now.difference(_lastFloorProgressAt!) <
+            const Duration(milliseconds: 400)) {
+      return;
+    }
+    final index = ScrollFloorNavigator.findLeadingVisiblePostIndex(
+      postKeys: _postKeys,
+    );
+    if (index == null) return;
+    _lastFloorProgressAt = now;
+    _recordProgress(state, floorInPage: index + 1);
+  }
 
-    if (widget.initialPage != null || widget.targetPid != null) {
-      return;
-    }
-
-    final record = ref.read(readingRecordProvider(widget.tid));
-    if (record == null || !record.isFinished) {
-      return;
-    }
-    if (!record.hasNewPages(state.totalPages)) {
-      return;
-    }
-
-    final targetPage = (record.totalPages + 1).clamp(1, state.totalPages);
-    if (state.currentPage >= targetPage) {
-      return;
-    }
+  Future<void> _consumeOpenScrollTarget(PostListState state) async {
+    if (_manualPageChange || _openScrollConsumed) return;
+    final target = state.openScrollTarget;
+    if (target == null) return;
 
     _pendingInitialNavigation = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    if (mounted) setState(() {});
+
+    final ok = await _applyOpenScrollTarget(state, target);
+    if (!mounted) return;
+
+    if (ok) {
+      _openScrollConsumed = true;
+      ref.read(postProvider(widget.tid).notifier).clearOpenScrollTarget();
+      setState(() => _pendingInitialNavigation = false);
+    } else {
+      // 懒列表尚未构建目标楼：短暂等待后重试。
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _openScrollConsumed) return;
+        unawaited(_consumeOpenScrollTarget(state));
+      });
+    }
+  }
+
+  Future<bool> _applyOpenScrollTarget(
+    PostListState state,
+    OpenScrollTarget target,
+  ) async {
+    switch (target) {
+      case ScrollToPageTop():
+        await _scrollToTopImpl();
+        return true;
+      case ScrollToPid(:final pid, :final highlight):
+        if (highlight) {
+          setState(() => _highlightPid = pid);
+        }
+        final index = state.posts.indexWhere((p) => p.pid == pid);
+        if (index < 0) return true;
+        _scheduleEnsurePostKeys(state.posts.length);
+        await WidgetsBinding.instance.endOfFrame;
+        return ScrollFloorNavigator.scrollToIndex(
+          postKeys: _postKeys,
+          index: index,
+          alignment: 0.15,
+        );
+      case ScrollToFloor(:final absoluteFloor):
+        final index = floorToPageIndex(
+          absoluteFloor: absoluteFloor,
+          page: state.currentPage,
+          perPage: state.perPage,
+          postCount: state.posts.length,
+        );
+        _scheduleEnsurePostKeys(state.posts.length);
+        await WidgetsBinding.instance.endOfFrame;
+        return ScrollFloorNavigator.scrollToIndex(
+          postKeys: _postKeys,
+          index: index,
+          alignment: 0.15,
+        );
+    }
+  }
+
+  void _maybeShowLocateError(PostListState state) {
+    final message = state.locateError;
+    if (message == null || message.isEmpty) return;
+    if (_shownLocateError == message) return;
+    _shownLocateError = message;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      await ref.read(postProvider(widget.tid).notifier).goToPage(targetPage);
-      if (mounted) {
-        setState(() => _pendingInitialNavigation = false);
-      }
+      S1SnackBar.show(context, message: message);
     });
   }
 
@@ -197,6 +265,11 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         showScrollDown: showDown,
         atPageBottom: atBottom,
       );
+    }
+
+    final data = ref.read(postProvider(widget.tid)).asData?.value;
+    if (data != null) {
+      _maybeRecordVisibleFloor(data);
     }
   }
 
@@ -256,9 +329,15 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     _scrollFabVisibility.value = const _ScrollFabVisibility();
     setState(() {
       _manualPageChange = true;
+      _openScrollConsumed = true;
+      _highlightPid = null;
       _postKeys = [];
     });
     await ref.read(postProvider(widget.tid).notifier).goToPage(page);
+    if (!mounted) return;
+    context.replace(
+      ThreadRouteCodec.encodePath(ThreadPage(widget.tid, page)),
+    );
   }
 
   bool _showsPollOnPage(PostListState state) =>
@@ -335,8 +414,11 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     PostListState state,
   ) async {
     final notifier = ref.read(postProvider(widget.tid).notifier);
+    setState(() {
+      _manualPageChange = false;
+      _openScrollConsumed = false;
+    });
     if (result.pid != null && result.pid!.isNotEmpty) {
-      setState(() => _highlightPid = result.pid);
       await notifier.locatePid(result.pid!);
     } else {
       await notifier.goToPage(state.totalPages);
@@ -357,25 +439,13 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
 
     final postIndex = _showsPollOnPage(state) && index > 1 ? index - 1 : index;
     final post = state.posts[postIndex];
-    final highlightPid = widget.targetPid ?? _highlightPid;
-    final isTarget = highlightPid != null && post.pid == highlightPid;
+    final highlightPid = _highlightPid ??
+        switch (state.openScrollTarget) {
+          ScrollToPid(:final pid, :final highlight) when highlight => pid,
+          _ => null,
+        };
 
     final postKey = postIndex < _postKeys.length ? _postKeys[postIndex] : null;
-
-    if (isTarget && !_manualPageChange && _scrollOncePid != post.pid) {
-      _scrollOncePid = post.pid;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        final ctx = postKey?.currentContext;
-        if (ctx != null) {
-          Scrollable.ensureVisible(
-            ctx,
-            alignment: 0.15,
-            duration: const Duration(milliseconds: 300),
-          );
-        }
-      });
-    }
 
     final floorOffset = (state.currentPage - 1) * state.perPage;
     final displayFloor = floorOffset + postIndex + 1;
@@ -418,7 +488,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
         displayFloor: displayFloor,
         tid: widget.tid,
         currentPage: state.currentPage,
-        isHighlighted: post.pid == highlightPid,
+        isHighlighted: highlightPid != null && post.pid == highlightPid,
         onFilterByAuthor: () {
           ref.read(postProvider(widget.tid).notifier).filterByAuthor(
                 post.authorId,
@@ -503,8 +573,12 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     ref.listen<AsyncValue<PostListState>>(postProvider(widget.tid),
         (previous, next) {
       next.whenData((state) {
-        _maybeCorrectNewReplyPage(state);
-        _recordProgress(state);
+        _maybeShowLocateError(state);
+        if (!_openScrollConsumed && state.openScrollTarget != null) {
+          unawaited(_consumeOpenScrollTarget(state));
+        } else {
+          _recordProgress(state);
+        }
       });
     });
 

--- a/lib/screens/user_space_screen.dart
+++ b/lib/screens/user_space_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../config/api_config.dart';
+import '../models/thread_destination.dart';
 import '../models/user_space_item.dart';
 import '../providers/reading_history_provider.dart';
 import '../providers/user_space_provider.dart';
@@ -374,13 +375,10 @@ class _ReplyCard extends StatelessWidget {
       shape: S1Shape.cardShape,
       child: InkWell(
         onTap: () {
-          final uri = Uri(
-            path: '/thread/${item.tid}',
-            queryParameters: {
-              if (item.pid != null) 'pid': item.pid,
-            },
-          );
-          context.push(uri.toString());
+          final destination = item.pid != null && item.pid!.isNotEmpty
+              ? ThreadPost(item.tid, item.pid!)
+              : ResumeThread(item.tid);
+          context.push(ThreadRouteCodec.encodePath(destination));
         },
         borderRadius: S1Shape.medium,
         child: Padding(

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1459,46 +1459,68 @@ class ApiService {
   final Map<String, int> _pageCache = {};
 
   /// 定位特定回复所在的页码。
+  ///
+  /// 失败时抛出 [StateError]，不再静默回落为第 1 页。
   Future<int> locatePostPage(String tid, String pid) async {
     final cacheKey = '$tid:$pid';
     final cached = _pageCache[cacheKey];
     if (cached != null) return cached;
 
-    final url = '${ApiConfig.baseUrl}/forum.php'
-        '?mod=redirect&goto=findpost&ptid=$tid&pid=$pid';
-    try {
-      // 原生平台：只拿 302 header，不下 body
-      final response = await _httpClient.get(
-        url,
-        options: Options(
-          followRedirects: false,
-          validateStatus: (s) => s != null && s < 500,
-          responseType: ResponseType.plain,
-        ),
-      );
+    final uri = Uri.parse('${ApiConfig.baseUrl}/forum.php').replace(
+      queryParameters: {
+        'mod': 'redirect',
+        'goto': 'findpost',
+        'ptid': tid,
+        'pid': pid,
+      },
+    );
+    final url = uri.toString();
 
-      // 优先从 Location header 解析
-      final location = response.headers.value('location');
-      if (location != null) {
-        final uri = Uri.parse(location);
-        final page = int.tryParse(uri.queryParameters['page'] ?? '1') ?? 1;
+    // 原生平台：只拿 302 header，不下 body
+    final response = await _httpClient.get(
+      url,
+      options: Options(
+        followRedirects: false,
+        validateStatus: (s) => s != null && s < 500,
+        responseType: ResponseType.plain,
+      ),
+    );
+
+    // 优先从 Location header 解析
+    final location = response.headers.value('location');
+    if (location != null) {
+      final redirected = Uri.parse(location);
+      final page =
+          int.tryParse(redirected.queryParameters['page'] ?? '') ??
+              _pageFromPseudoStaticPath(redirected.path);
+      if (page != null && page >= 1) {
         _pageCache[cacheKey] = page;
         return page;
       }
+    }
 
-      // Web 代理已跟随重定向，从响应 HTML 解析
-      final html = response.data as String;
-      final pageMatch = RegExp(
-        r'<strong[^>]*>(\d+)</strong>|class="cur"[^>]*>(\d+)<',
-      ).firstMatch(html);
-      if (pageMatch != null) {
-        final p = pageMatch.group(1) ?? pageMatch.group(2) ?? '';
-        final page = int.tryParse(p) ?? 1;
+    // Web 代理已跟随重定向，从响应 HTML 解析
+    final html = response.data as String? ?? '';
+    final pageMatch = RegExp(
+      r'<strong[^>]*>(\d+)</strong>|class="cur"[^>]*>(\d+)<',
+    ).firstMatch(html);
+    if (pageMatch != null) {
+      final p = pageMatch.group(1) ?? pageMatch.group(2) ?? '';
+      final page = int.tryParse(p);
+      if (page != null && page >= 1) {
         _pageCache[cacheKey] = page;
         return page;
       }
-    } catch (_) {}
-    return 1;
+    }
+
+    throw StateError('locatePostPage failed for tid=$tid pid=$pid');
+  }
+
+  /// 解析 `thread-{tid}-{page}-1.html` 伪静态路径中的页码。
+  static int? _pageFromPseudoStaticPath(String path) {
+    final match = RegExp(r'thread-\d+-(\d+)-\d+\.html').firstMatch(path);
+    if (match == null) return null;
+    return int.tryParse(match.group(1) ?? '');
   }
 
   /// 获取私信会话列表（优先 Mobile API，失败时 HTML 兜底）。

--- a/lib/utils/scroll_floor.dart
+++ b/lib/utils/scroll_floor.dart
@@ -155,23 +155,51 @@ abstract class ScrollFloorNavigator {
     if (viewportDimension <= 0) return false;
 
     var targetContext = postKeys[index].currentContext;
-    if (targetContext == null) {
-      // 估算：按近似行高推进到目标附近。
-      final estimated =
-          (position.pixels + index * viewportDimension * 0.45).clamp(
-        position.minScrollExtent,
-        position.maxScrollExtent,
-      );
+    // 目标尚未构建时：以最近已构建楼为锚，按实测行高多轮估算滚入视口。
+    for (var attempt = 0;
+        targetContext == null && attempt < 6;
+        attempt++) {
+      var refIndex = -1;
+      for (var i = index - 1; i >= 0; i--) {
+        if (postKeys[i].currentContext != null) {
+          refIndex = i;
+          break;
+        }
+      }
+      if (refIndex < 0) {
+        for (var i = index + 1; i < postKeys.length; i++) {
+          if (postKeys[i].currentContext != null) {
+            refIndex = i;
+            break;
+          }
+        }
+      }
+      if (refIndex < 0) return false;
+
+      final refContext = postKeys[refIndex].currentContext!;
+      if (!refContext.mounted) return false;
+      final refRender = refContext.findRenderObject();
+      if (refRender == null || !refRender.attached) return false;
+      final refViewport = RenderAbstractViewport.maybeOf(refRender);
+      if (refViewport == null) return false;
+      final refTop = refViewport.getOffsetToReveal(refRender, 0).offset;
+      final itemHeight = refRender.paintBounds.height;
+      if (itemHeight <= 0) return false;
+
+      // 每轮最多推进约一屏，逐步拉近懒列表构建窗口。
+      final remaining = index - refIndex;
+      final stepCount = remaining.abs().clamp(1, 8);
+      final direction = remaining >= 0 ? 1 : -1;
+      final estimated = (refTop +
+              direction * stepCount * itemHeight -
+              viewportDimension * alignment)
+          .clamp(position.minScrollExtent, position.maxScrollExtent);
+
       await S1ScrollMotion.animateTo(position, estimated);
       await WidgetsBinding.instance.endOfFrame;
       targetContext = postKeys[index].currentContext;
-      if (targetContext == null) {
-        await S1ScrollMotion.correctSilentlyIfNeeded(position, estimated);
-        await WidgetsBinding.instance.endOfFrame;
-        targetContext = postKeys[index].currentContext;
-      }
-      if (targetContext == null) return false;
     }
+    if (targetContext == null) return false;
 
     if (!targetContext.mounted) return false;
     final render = targetContext.findRenderObject();

--- a/lib/utils/scroll_floor.dart
+++ b/lib/utils/scroll_floor.dart
@@ -120,4 +120,115 @@ abstract class ScrollFloorNavigator {
 
     await S1ScrollMotion.animateTo(position, targetScroll);
   }
+
+  /// 将 [postKeys] 中 [index] 对应楼滚至 [revealAlignment]。
+  ///
+  /// 目标尚未被懒列表构建时：先估算滚动拉入视口，再校正。
+  static Future<bool> scrollToIndex({
+    required List<GlobalKey> postKeys,
+    required int index,
+    double alignment = revealAlignment,
+  }) async {
+    if (postKeys.isEmpty || index < 0 || index >= postKeys.length) {
+      return false;
+    }
+
+    BuildContext? anchorContext;
+    for (final key in postKeys) {
+      if (key.currentContext != null) {
+        anchorContext = key.currentContext;
+        break;
+      }
+    }
+    // 全未构建：尝试用 index 0 的 key 所在 Scrollable 不可用时，直接失败由调用方重试。
+    anchorContext ??= postKeys[index].currentContext;
+    if (anchorContext == null) {
+      // 强制触发离屏项：找任一已附着的 Scrollable（经 postKeys 外部传入的 ancestor）。
+      return false;
+    }
+
+    final scrollable = Scrollable.maybeOf(anchorContext);
+    if (scrollable == null) return false;
+
+    final position = scrollable.position;
+    final viewportDimension = position.viewportDimension;
+    if (viewportDimension <= 0) return false;
+
+    var targetContext = postKeys[index].currentContext;
+    if (targetContext == null) {
+      // 估算：按近似行高推进到目标附近。
+      final estimated =
+          (position.pixels + index * viewportDimension * 0.45).clamp(
+        position.minScrollExtent,
+        position.maxScrollExtent,
+      );
+      await S1ScrollMotion.animateTo(position, estimated);
+      await WidgetsBinding.instance.endOfFrame;
+      targetContext = postKeys[index].currentContext;
+      if (targetContext == null) {
+        await S1ScrollMotion.correctSilentlyIfNeeded(position, estimated);
+        await WidgetsBinding.instance.endOfFrame;
+        targetContext = postKeys[index].currentContext;
+      }
+      if (targetContext == null) return false;
+    }
+
+    if (!targetContext.mounted) return false;
+    final render = targetContext.findRenderObject();
+    if (render == null || !render.attached) return false;
+    final viewport = RenderAbstractViewport.maybeOf(render);
+    if (viewport == null) return false;
+
+    final targetScroll = viewport
+        .getOffsetToReveal(render, alignment)
+        .offset
+        .clamp(position.minScrollExtent, position.maxScrollExtent);
+
+    final delta = (targetScroll - position.pixels).abs();
+    if (delta > alignSkipTolerance) {
+      await S1ScrollMotion.animateTo(position, targetScroll);
+    }
+    return true;
+  }
+
+  /// 根据 [_postKeys] 与视口，解析当前“靠上可见”的页内楼层索引（0-based）。
+  static int? findLeadingVisiblePostIndex({
+    required List<GlobalKey> postKeys,
+  }) {
+    if (postKeys.isEmpty) return null;
+
+    BuildContext? anchorContext;
+    for (final key in postKeys) {
+      if (key.currentContext != null) {
+        anchorContext = key.currentContext;
+        break;
+      }
+    }
+    if (anchorContext == null) return null;
+
+    final scrollable = Scrollable.maybeOf(anchorContext);
+    if (scrollable == null) return null;
+    final position = scrollable.position;
+    final viewportDimension = position.viewportDimension;
+    if (viewportDimension <= 0) return null;
+
+    final anchorContentY =
+        position.pixels + viewportDimension * revealAlignment;
+
+    var currentIndex = -1;
+    for (var i = 0; i < postKeys.length; i++) {
+      final ctx = postKeys[i].currentContext;
+      if (ctx == null) continue;
+      final renderObject = ctx.findRenderObject();
+      if (renderObject == null || !renderObject.attached) continue;
+      final viewport = RenderAbstractViewport.maybeOf(renderObject);
+      if (viewport == null) continue;
+      final itemTop = viewport.getOffsetToReveal(renderObject, 0).offset;
+      if (itemTop <= anchorContentY + 0.5) {
+        currentIndex = i;
+      }
+    }
+    if (currentIndex < 0) return 0;
+    return currentIndex;
+  }
 }

--- a/lib/utils/thread_navigation.dart
+++ b/lib/utils/thread_navigation.dart
@@ -1,6 +1,11 @@
 import '../config/constants.dart';
+import '../models/open_scroll_target.dart';
 import '../models/reading_record.dart';
+import '../models/thread_destination.dart';
 import '../models/thread_open_intent.dart';
+
+/// 续读预编码标记：`?page=N&resume=1` 仍为 [ThreadOpenMode.resume]，不是强制页。
+const String kThreadResumeQuery = 'resume';
 
 /// 由回复数推算总页数（与列表卡片一致）。
 int calcThreadTotalPages(
@@ -11,14 +16,31 @@ int calcThreadTotalPages(
   return (totalPosts / perPage).ceil().clamp(1, 9999);
 }
 
+/// 绝对楼层 → 当前页内 0-based 索引；越界时钳到 `[0, postCount-1]`。
+int floorToPageIndex({
+  required int absoluteFloor,
+  required int page,
+  required int perPage,
+  required int postCount,
+}) {
+  if (postCount <= 0) return 0;
+  final pageStart = (page - 1) * perPage + 1;
+  final raw = absoluteFloor - pageStart;
+  return raw.clamp(0, postCount - 1);
+}
+
 /// 解析打开详情时的目标页（不含 pid 定位；pid 场景需异步 locate）。
 int resolveThreadInitialPage({
   required ThreadOpenIntent? intent,
   required ReadingRecord? record,
 }) {
-  final explicitPage = intent?.initialPage;
-  if (explicitPage != null && explicitPage > 1) {
-    return explicitPage;
+  final mode = intent?.mode ?? ThreadOpenMode.resume;
+
+  if (mode == ThreadOpenMode.page) {
+    final explicitPage = intent?.page;
+    if (explicitPage != null && explicitPage >= 1) {
+      return explicitPage;
+    }
   }
 
   if (record != null) {
@@ -32,7 +54,120 @@ int resolveThreadInitialPage({
   return 1;
 }
 
-/// 根据阅读记录构建帖子详情路由路径。
+/// resume 打开落点：B3 新页 → 页顶；否则 → 滚到 [ReadingRecord.lastReadFloor]。
+OpenScrollTarget resolveResumeScrollTarget({
+  required ReadingRecord? record,
+  required int loadedPage,
+  required int totalPages,
+}) {
+  if (record == null) {
+    return const ScrollToPageTop();
+  }
+
+  final live = totalPages;
+  if (record.isFinished && record.hasNewPages(live)) {
+    final b3Page = (record.totalPages + 1).clamp(1, live);
+    if (loadedPage == b3Page) {
+      return const ScrollToPageTop();
+    }
+  }
+
+  final floor = record.lastReadFloor;
+  if (floor <= 0) {
+    return const ScrollToPageTop();
+  }
+  return ScrollToFloor(floor);
+}
+
+/// Destination ↔ URI 编解码。
+abstract final class ThreadRouteCodec {
+  static Uri encode(ThreadDestination destination) {
+    final tid = destination.tid;
+    switch (destination) {
+      case ResumeThread():
+        return Uri(path: '/thread/$tid');
+      case ThreadPage(:final page):
+        return Uri(
+          path: '/thread/$tid',
+          queryParameters: {'page': '$page'},
+        );
+      case ThreadPost(:final pid):
+        return Uri(
+          path: '/thread/$tid',
+          queryParameters: {'pid': pid},
+        );
+    }
+  }
+
+  /// 将 destination 编为 go_router 可用的 location 字符串。
+  static String encodePath(ThreadDestination destination) =>
+      encode(destination).toString();
+
+  /// 从路由 URI 解码。非法 / 缺失 page → resume。
+  ///
+  /// 优先级：`pid` > 强制 `page` > `page`+`resume=1`（续读提示）> 裸路径 resume。
+  static ThreadDestination decode(Uri uri, {required String tid}) {
+    final pid = uri.queryParameters['pid'];
+    if (pid != null && pid.isNotEmpty) {
+      return ThreadPost(tid, pid);
+    }
+
+    final pageStr = uri.queryParameters['page'];
+    final page = pageStr != null ? int.tryParse(pageStr) : null;
+    final isResumeHint = uri.queryParameters[kThreadResumeQuery] == '1';
+
+    if (page != null && page >= 1 && !isResumeHint) {
+      return ThreadPage(tid, page);
+    }
+
+    return ResumeThread(tid);
+  }
+
+  static ThreadOpenIntent toIntent(
+    ThreadDestination destination, {
+    int? liveTotalPages,
+    int? resumePageHint,
+  }) {
+    switch (destination) {
+      case ResumeThread():
+        return ThreadOpenIntent.resume(
+          page: resumePageHint,
+          liveTotalPages: liveTotalPages,
+        );
+      case ThreadPage(:final page):
+        return ThreadOpenIntent.page(page, liveTotalPages: liveTotalPages);
+      case ThreadPost(:final pid):
+        return ThreadOpenIntent.post(pid, liveTotalPages: liveTotalPages);
+    }
+  }
+
+  /// 从完整路由 URI 生成 Intent（含 `resume=1` 预解析页提示）。
+  static ThreadOpenIntent intentFromUri(Uri uri, {required String tid}) {
+    final destination = decode(uri, tid: tid);
+    final pageStr = uri.queryParameters['page'];
+    final page = pageStr != null ? int.tryParse(pageStr) : null;
+    final resumeHint = uri.queryParameters[kThreadResumeQuery] == '1'
+        ? (page != null && page >= 1 ? page : null)
+        : null;
+    return toIntent(destination, resumePageHint: resumeHint);
+  }
+
+  /// 续读并预带页码（防闪页）：`/thread/{tid}?page=N&resume=1`。
+  static String encodeResumeWithPageHint(String tid, int page) {
+    if (page <= 1) {
+      return encodePath(ResumeThread(tid));
+    }
+    return Uri(
+      path: '/thread/$tid',
+      queryParameters: {
+        'page': '$page',
+        kThreadResumeQuery: '1',
+      },
+    ).toString();
+  }
+}
+
+/// 根据阅读记录构建帖子详情路由路径（resume；页 > 1 时带 resume 标记预编码）。
 String buildThreadDetailPath(
   String tid, {
   ReadingRecord? record,
@@ -41,8 +176,5 @@ String buildThreadDetailPath(
   final pages = liveTotalPages ?? record?.totalPages;
   final targetPage =
       record != null && pages != null ? record.resolveOpenPage(pages) : 1;
-  if (targetPage <= 1) {
-    return '/thread/$tid';
-  }
-  return '/thread/$tid?page=$targetPage';
+  return ThreadRouteCodec.encodeResumeWithPageHint(tid, targetPage);
 }

--- a/lib/widgets/quote_block.dart
+++ b/lib/widgets/quote_block.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import '../models/thread_destination.dart';
 import '../theme/app_theme.dart';
 import '../utils/post_image_index_counter.dart';
 import '../utils/quote_jump.dart';
+import '../utils/thread_navigation.dart';
 import 'bbcode_renderer.dart';
 
 class QuoteBlock extends StatelessWidget {
@@ -204,10 +206,9 @@ class QuoteBlock extends StatelessWidget {
     BuildContext context,
     ({String tid, String? pid}) link,
   ) {
-    if (link.pid != null) {
-      context.push('/thread/${link.tid}?pid=${link.pid}');
-    } else {
-      context.push('/thread/${link.tid}');
-    }
+    final destination = link.pid != null
+        ? ThreadPost(link.tid, link.pid!)
+        : ResumeThread(link.tid);
+    context.push(ThreadRouteCodec.encodePath(destination));
   }
 }

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -5,6 +5,7 @@ import '../config/constants.dart';
 import '../models/thread.dart';
 import '../providers/reading_history_provider.dart';
 import '../theme/app_theme.dart';
+import '../models/thread_destination.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
 import '../utils/thread_navigation.dart';
@@ -38,7 +39,9 @@ class ThreadCard extends ConsumerWidget {
   void _showPageSheet(BuildContext context) {
     final totalPages = _calcTotalPages(thread.replies);
     if (totalPages <= 1) {
-      context.push('/thread/${thread.tid}');
+      context.push(
+        ThreadRouteCodec.encodePath(ThreadPage(thread.tid, 1)),
+      );
       return;
     }
 
@@ -54,9 +57,7 @@ class ThreadCard extends ConsumerWidget {
       },
       onPageSelected: (page) {
         context.push(
-          page == 1
-              ? '/thread/${thread.tid}'
-              : '/thread/${thread.tid}?page=$page',
+          ThreadRouteCodec.encodePath(ThreadPage(thread.tid, page)),
         );
       },
     );

--- a/test/providers/post_provider_open_intent_test.dart
+++ b/test/providers/post_provider_open_intent_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/open_scroll_target.dart';
 import 'package:s1_app/models/reading_record.dart';
 import 'package:s1_app/models/thread_open_intent.dart';
 import 'package:s1_app/providers/post_provider.dart';
@@ -43,11 +44,11 @@ void main() {
       container.dispose();
     });
 
-    test('A2 initialPage=5 loads page 5 on first request', () async {
+    test('page mode loads explicit page on first request', () async {
       container = buildContainer(
         extraOverrides: [
           threadOpenIntentProvider('100').overrideWithValue(
-            const ThreadOpenIntent(initialPage: 5),
+            const ThreadOpenIntent.page(5),
           ),
         ],
       );
@@ -57,14 +58,46 @@ void main() {
       expect(state.currentPage, 5);
       expect(adapter.requestedPages, [5]);
       expect(adapter.requestedPages, isNot(contains(1)));
+      expect(state.openScrollTarget, isA<ScrollToPageTop>());
     });
 
-    test('A5/A6 targetPid locates page before loading detail', () async {
+    test('page=1 forces first page over resume record', () async {
+      container = buildContainer(
+        extraOverrides: [
+          threadOpenIntentProvider('100').overrideWithValue(
+            const ThreadOpenIntent.page(1),
+          ),
+          readingRecordProvider('100').overrideWithValue(
+            ReadingRecord(
+              tid: '100',
+              subject: 't',
+              author: 'a',
+              fid: '4',
+              lastReadPage: 4,
+              lastReadFloor: 120,
+              totalPages: 8,
+              totalReplies: 0,
+              perPage: 40,
+              lastReadAt: 1,
+              firstReadAt: 1,
+              readCount: 1,
+            ),
+          ),
+        ],
+      );
+
+      final state = await container.read(postProvider('100').future);
+      expect(state.currentPage, 1);
+      expect(adapter.requestedPages, [1]);
+      expect(state.openScrollTarget, isA<ScrollToPageTop>());
+    });
+
+    test('post mode locates page before loading detail', () async {
       adapter.locatePageForPid['999'] = 187;
       container = buildContainer(
         extraOverrides: [
           threadOpenIntentProvider('100').overrideWithValue(
-            const ThreadOpenIntent(targetPid: '999'),
+            const ThreadOpenIntent.post('999'),
           ),
         ],
       );
@@ -77,9 +110,28 @@ void main() {
       expect(adapter.locateRequests, contains('100:999'));
       expect(adapter.requestedPages, [187]);
       expect(adapter.requestedPages, isNot(contains(1)));
+      expect(state.openScrollTarget, isA<ScrollToPid>());
+      expect((state.openScrollTarget as ScrollToPid).pid, '999');
+      expect(state.locateError, isNull);
     });
 
-    test('reading record resume loads lastReadPage without page=1 flash',
+    test('post mode sets locateError when pid missing on page', () async {
+      adapter.locatePageForPid['999'] = 2;
+      adapter.omitPidFromPostlist = true;
+      container = buildContainer(
+        extraOverrides: [
+          threadOpenIntentProvider('100').overrideWithValue(
+            const ThreadOpenIntent.post('999'),
+          ),
+        ],
+      );
+
+      final state = await container.read(postProvider('100').future);
+      expect(state.locateError, '未找到目标楼层');
+      expect(state.openScrollTarget, isA<ScrollToPageTop>());
+    });
+
+    test('reading record resume loads lastReadPage with ScrollToFloor',
         () async {
       container = buildContainer(
         extraOverrides: [
@@ -90,7 +142,7 @@ void main() {
               author: 'a',
               fid: '4',
               lastReadPage: 3,
-              lastReadFloor: 1,
+              lastReadFloor: 85,
               totalPages: 8,
               totalReplies: 0,
               perPage: 40,
@@ -106,6 +158,37 @@ void main() {
 
       expect(state.currentPage, 3);
       expect(adapter.requestedPages, [3]);
+      expect(state.openScrollTarget, isA<ScrollToFloor>());
+      expect((state.openScrollTarget as ScrollToFloor).absoluteFloor, 85);
+    });
+
+    test('B3 finished with new pages opens new page at top', () async {
+      container = buildContainer(
+        extraOverrides: [
+          readingRecordProvider('100').overrideWithValue(
+            ReadingRecord(
+              tid: '100',
+              subject: 't',
+              author: 'a',
+              fid: '4',
+              lastReadPage: 2,
+              lastReadFloor: 80,
+              totalPages: 2,
+              totalReplies: 79,
+              perPage: 40,
+              lastReadAt: 1,
+              firstReadAt: 1,
+              readCount: 1,
+            ),
+          ),
+        ],
+      );
+      // adapter replies=159 → totalPages = ceil(160/40)=4
+      final state = await container.read(postProvider('100').future);
+
+      expect(state.currentPage, 3);
+      expect(state.openScrollTarget, isA<ScrollToPageTop>());
+      expect(adapter.requestedPages, contains(3));
     });
 
     test('fetches rate logs when commentcount is zero', () async {
@@ -202,6 +285,8 @@ class _ThreadDetailAdapter implements HttpClientAdapter {
   final rateLogRequests = <Uri>[];
   Map<String, int>? commentCount;
   String rateLogHtml = '<html></html>';
+  bool omitPidFromPostlist = false;
+  String? _lastLocatedPid;
 
   @override
   void close({bool force = false}) {}
@@ -218,6 +303,7 @@ class _ThreadDetailAdapter implements HttpClientAdapter {
       final ptid = uri.queryParameters['ptid'] ?? '';
       final pid = uri.queryParameters['pid'] ?? '';
       locateRequests.add('$ptid:$pid');
+      _lastLocatedPid = pid;
       final page = locatePageForPid[pid] ?? 1;
       return ResponseBody.fromString(
         '',
@@ -233,6 +319,9 @@ class _ThreadDetailAdapter implements HttpClientAdapter {
     if (uri.query.contains('module=viewthread')) {
       final page = int.tryParse(uri.queryParameters['page'] ?? '1') ?? 1;
       requestedPages.add(page);
+      final pid = omitPidFromPostlist
+          ? '1'
+          : (_lastLocatedPid ?? '1');
       final variables = <String, dynamic>{
         'ppp': '40',
         'thread': {
@@ -243,7 +332,7 @@ class _ThreadDetailAdapter implements HttpClientAdapter {
         },
         'postlist': [
           {
-            'pid': '1',
+            'pid': pid,
             'author': 'user',
             'authorid': '1',
             'message': 'body',

--- a/test/providers/post_provider_open_intent_test.dart
+++ b/test/providers/post_provider_open_intent_test.dart
@@ -125,6 +125,8 @@ void main() {
           ),
         ],
       );
+      final sub = container.listen(postProvider('100'), (_, __) {});
+      addTearDown(sub.close);
 
       final state = await container.read(postProvider('100').future);
       expect(state.locateError, '未找到目标楼层');
@@ -153,6 +155,8 @@ void main() {
           ),
         ],
       );
+      final sub = container.listen(postProvider('100'), (_, __) {});
+      addTearDown(sub.close);
 
       final state = await container.read(postProvider('100').future);
 
@@ -183,6 +187,8 @@ void main() {
           ),
         ],
       );
+      final sub = container.listen(postProvider('100'), (_, __) {});
+      addTearDown(sub.close);
       // adapter replies=159 → totalPages = ceil(160/40)=4
       final state = await container.read(postProvider('100').future);
 

--- a/test/screens/thread_detail_nav_integration_test.dart
+++ b/test/screens/thread_detail_nav_integration_test.dart
@@ -1,0 +1,381 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:s1_app/models/user.dart';
+import 'package:s1_app/models/open_scroll_target.dart';
+import 'package:s1_app/providers/auth_provider.dart';
+import 'package:s1_app/providers/post_provider.dart';
+import 'package:s1_app/providers/reading_history_provider.dart';
+import 'package:s1_app/providers/settings_provider.dart';
+import 'package:s1_app/providers/thread_open_intent_provider.dart';
+import 'package:s1_app/screens/thread_detail_screen.dart';
+import 'package:s1_app/services/http_client.dart';
+import 'package:s1_app/services/reading_history_service.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/utils/thread_navigation.dart';
+import 'package:s1_app/widgets/pagination_bar.dart';
+
+import '../helpers/test_local_data.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, int frames) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+/// Integration coverage for thread open contract + URL sync + floor resume.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _ViewthreadAdapter adapter;
+  late ProviderContainer? rootContainer;
+
+  setUp(() {
+    adapter = _ViewthreadAdapter();
+    rootContainer = null;
+  });
+
+  tearDown(() {
+    rootContainer?.dispose();
+  });
+
+  Future<GoRouter> pumpThread({
+    required WidgetTester tester,
+    required String location,
+    void Function(ReadingHistoryService service)? seedHistory,
+  }) async {
+    final (db, local) = await openTestLocalData();
+    addTearDown(db.close);
+    await local.ensureReadingHistoryLoaded();
+    await local.ensureBlacklistLoaded();
+    await local.ensurePollVotesLoaded();
+
+    final dio = Dio()..httpClientAdapter = adapter;
+    final uri = Uri.parse(location);
+    final tid = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : '100';
+    final intent = ThreadRouteCodec.intentFromUri(uri, tid: tid);
+    late ProviderContainer container;
+    container = ProviderContainer(
+      overrides: [
+        localDataProvider.overrideWithValue(local),
+        httpClientProvider.overrideWith(
+          (ref) => S1HttpClient.test(container, dio),
+        ),
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(
+            initial: const AppSettings(
+              showImages: false,
+              recordReadingHistory: true,
+            ),
+          ),
+        ),
+        authStateProvider.overrideWith(_GuestAuthNotifier.new),
+        // Override on the same container PostNotifier reads from.
+        // Nested ProviderScope overrides are not visible to parent providers.
+        threadOpenIntentProvider(tid).overrideWithValue(intent),
+      ],
+    );
+    rootContainer = container;
+    seedHistory?.call(container.read(readingHistoryServiceProvider));
+    // Rebuild readingHistoryProvider after seed.
+    container.read(readingHistoryProvider.notifier).refresh();
+
+    final router = GoRouter(
+      initialLocation: location,
+      routes: [
+        GoRoute(
+          path: '/thread/:tid',
+          pageBuilder: (context, state) {
+            final routeTid = state.pathParameters['tid']!;
+            return NoTransitionPage<void>(
+              key: ValueKey('thread-$routeTid'),
+              child: ThreadDetailScreen(tid: routeTid),
+            );
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: AppTheme.lightTheme('purple'),
+          routerConfig: router,
+        ),
+      ),
+    );
+
+    // Allow open-scroll consume + rate-log side effects to settle.
+    for (var i = 0; i < 80; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      if (find.byType(PaginationBar).evaluate().isNotEmpty ||
+          find.textContaining('MARK-FLOOR-').evaluate().isNotEmpty) {
+        // Extra frames for open-scroll animations.
+        await _pumpFrames(tester, 20);
+        break;
+      }
+    }
+    return router;
+  }
+
+  testWidgets('in-thread next page replaces URL with ?page=', (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final router = await pumpThread(
+      tester: tester,
+      location: '/thread/100?page=1',
+    );
+
+    expect(find.text('第 1 / 3 页'), findsOneWidget);
+    expect(router.state.uri.toString(), '/thread/100?page=1');
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await _pumpFrames(tester, 40);
+
+    expect(find.text('第 2 / 3 页'), findsOneWidget);
+    expect(router.state.uri.queryParameters['page'], '2');
+    expect(router.state.uri.queryParameters.containsKey('pid'), isFalse);
+  });
+
+  testWidgets('resume opens mid-floor and writeback updates lastReadFloor',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    adapter.postsPerPage = 8;
+    adapter.totalReplies = 20;
+
+    await pumpThread(
+      tester: tester,
+      location: '/thread/100',
+      seedHistory: (service) {
+        service.updateProgress(
+          tid: '100',
+          page: 1,
+          floorInPage: 5,
+          subject: 'Nav Integration',
+          author: 'author',
+          fid: '4',
+          totalPages: 3,
+          totalReplies: 20,
+          perPage: 8,
+          isNewVisit: true,
+        );
+      },
+    );
+
+    // Absolute floor 5 should be scrolled into view after resume.
+    expect(find.textContaining('MARK-FLOOR-5'), findsOneWidget);
+
+    final before =
+        rootContainer!.read(readingHistoryServiceProvider).getRecord('100')!;
+    // After resume consume, visible-floor writeback should keep mid-floor
+    // (not the old page-end fake progress).
+    expect(before.lastReadFloor, inInclusiveRange(4, 6));
+
+    // Drive the detail ListView controller so scroll metrics fire.
+    final listFinder = find.descendant(
+      of: find.byType(ThreadDetailScreen),
+      matching: find.byType(ListView),
+    );
+    final listView = tester.widget<ListView>(listFinder);
+    final controller = listView.controller!;
+    expect(controller.position.maxScrollExtent, greaterThan(500));
+
+    // Throttle uses wall-clock DateTime.now(); advance real time via runAsync.
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 450)),
+    );
+
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await _pumpFrames(tester, 15);
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 450)),
+    );
+    // Nudge once more after lazy children build (extent may grow).
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await _pumpFrames(tester, 15);
+
+    final after =
+        rootContainer!.read(readingHistoryServiceProvider).getRecord('100')!;
+    expect(after.lastReadFloor, greaterThan(before.lastReadFloor));
+    expect(after.lastReadPage, 1);
+  });
+
+  testWidgets('forced page=1 ignores resume floor and stays at page top',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    adapter.postsPerPage = 8;
+    adapter.totalReplies = 40;
+
+    await pumpThread(
+      tester: tester,
+      location: '/thread/100?page=1',
+      seedHistory: (service) {
+        service.updateProgress(
+          tid: '100',
+          page: 2,
+          floorInPage: 4,
+          subject: 'Nav Integration',
+          author: 'author',
+          fid: '4',
+          totalPages: 6,
+          totalReplies: 40,
+          perPage: 8,
+          isNewVisit: true,
+        );
+      },
+    );
+
+    final state = rootContainer!.read(postProvider('100')).asData?.value;
+    expect(state, isNotNull);
+    expect(state!.currentPage, 1);
+    expect(adapter.requestedPages.first, 1);
+    // Force-page lands at page top (ScrollToPageTop already consumed).
+    expect(state.openScrollTarget, isNull);
+    expect(find.textContaining('MARK-FLOOR-1'), findsOneWidget);
+    expect(find.textContaining('MARK-FLOOR-12'), findsNothing);
+  });
+
+  testWidgets('pid open highlights target and ignores resume floor',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    adapter.postsPerPage = 8;
+    adapter.totalReplies = 20;
+    adapter.locatePageForPid['pid-6'] = 1;
+
+    await pumpThread(
+      tester: tester,
+      location: '/thread/100?pid=pid-6',
+      seedHistory: (service) {
+        service.updateProgress(
+          tid: '100',
+          page: 1,
+          floorInPage: 2,
+          subject: 'Nav Integration',
+          author: 'author',
+          fid: '4',
+          totalPages: 3,
+          totalReplies: 20,
+          perPage: 8,
+          isNewVisit: true,
+        );
+      },
+    );
+
+    final state = rootContainer!.read(postProvider('100')).asData?.value;
+    expect(state, isNotNull);
+    expect(state!.currentPage, 1);
+    expect(state.posts.any((p) => p.pid == 'pid-6'), isTrue);
+    expect(state.locateError, isNull);
+    // Resume floor must not override pid intent.
+    expect(state.openScrollTarget, anyOf(isNull, isA<ScrollToPid>()));
+    expect(find.textContaining('MARK-FLOOR-6'), findsOneWidget);
+  });
+}
+
+class _GuestAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() {
+    return AuthState(
+      isLoggedIn: false,
+      username: null,
+      user: User(uid: '', username: ''),
+    );
+  }
+}
+
+class _ViewthreadAdapter implements HttpClientAdapter {
+  int postsPerPage = 3;
+  int totalReplies = 8;
+  final requestedPages = <int>[];
+  final locatePageForPid = <String, int>{};
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final uri = options.uri;
+
+    if (uri.queryParameters['goto'] == 'findpost') {
+      final pid = uri.queryParameters['pid'] ?? '';
+      final ptid = uri.queryParameters['ptid'] ?? '';
+      final page = locatePageForPid[pid] ?? 1;
+      return ResponseBody.fromString(
+        '',
+        302,
+        headers: {
+          'location': [
+            'https://stage1st.com/2b/forum.php?mod=viewthread&tid=$ptid&page=$page',
+          ],
+        },
+      );
+    }
+
+    if (uri.query.contains('module=viewthread')) {
+      final page = int.tryParse(uri.queryParameters['page'] ?? '1') ?? 1;
+      requestedPages.add(page);
+      final posts = <Map<String, dynamic>>[];
+      for (var i = 0; i < postsPerPage; i++) {
+        final absoluteFloor = (page - 1) * postsPerPage + i + 1;
+        // Tall plain-text posts (avoid heavy HTML) so floor scroll/writeback work.
+        final spacer = List.filled(30, 'line$absoluteFloor').join('\n');
+        posts.add({
+          'pid': 'pid-$absoluteFloor',
+          'author': 'author$absoluteFloor',
+          'authorid': '$absoluteFloor',
+          'message': 'MARK-FLOOR-$absoluteFloor\n$spacer',
+          'dateline': '1700000000',
+          'dbdateline': '1700000000',
+          'number': '$absoluteFloor',
+        });
+      }
+
+      return ResponseBody.fromString(
+        jsonEncode({
+          'Variables': {
+            'ppp': '$postsPerPage',
+            'thread': {
+              'subject': 'Nav Integration',
+              'fid': '4',
+              'replies': '$totalReplies',
+              'allowreply': '1',
+            },
+            'postlist': posts,
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+
+    if (uri.query.contains('mod=viewthread')) {
+      return ResponseBody.fromString('<html></html>', 200);
+    }
+
+    return ResponseBody.fromString('{}', 200);
+  }
+}

--- a/test/screens/thread_detail_progress_dedup_test.dart
+++ b/test/screens/thread_detail_progress_dedup_test.dart
@@ -7,18 +7,22 @@ void main() {
       shouldWriteReadingProgressUpdate(
         hasRecordedInitialVisit: false,
         lastRecordedPage: null,
+        lastRecordedFloorInPage: null,
         currentPage: 1,
+        currentFloorInPage: 1,
       ),
       isTrue,
     );
   });
 
-  test('same page after initial visit skips write', () {
+  test('same page and floor after initial visit skips write', () {
     expect(
       shouldWriteReadingProgressUpdate(
         hasRecordedInitialVisit: true,
         lastRecordedPage: 2,
+        lastRecordedFloorInPage: 5,
         currentPage: 2,
+        currentFloorInPage: 5,
       ),
       isFalse,
     );
@@ -29,7 +33,22 @@ void main() {
       shouldWriteReadingProgressUpdate(
         hasRecordedInitialVisit: true,
         lastRecordedPage: 2,
+        lastRecordedFloorInPage: 5,
         currentPage: 3,
+        currentFloorInPage: 1,
+      ),
+      isTrue,
+    );
+  });
+
+  test('floor change on same page writes progress', () {
+    expect(
+      shouldWriteReadingProgressUpdate(
+        hasRecordedInitialVisit: true,
+        lastRecordedPage: 2,
+        lastRecordedFloorInPage: 5,
+        currentPage: 2,
+        currentFloorInPage: 12,
       ),
       isTrue,
     );

--- a/test/utils/scroll_floor_index_test.dart
+++ b/test/utils/scroll_floor_index_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/theme/app_theme.dart';
+import 'package:s1_app/utils/scroll_floor.dart';
+
+void main() {
+  testWidgets('scrollToIndex brings a distant index into view', (tester) async {
+    final keys = List.generate(40, (_) => GlobalKey());
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme('purple'),
+        home: Scaffold(
+          body: ListView.builder(
+            itemCount: keys.length,
+            itemBuilder: (context, index) {
+              return SizedBox(
+                key: keys[index],
+                height: 120,
+                child: Text('floor-$index'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('floor-0'), findsOneWidget);
+    expect(find.text('floor-25'), findsNothing);
+
+    final ok = await ScrollFloorNavigator.scrollToIndex(
+      postKeys: keys,
+      index: 25,
+    );
+    await tester.pumpAndSettle();
+
+    expect(ok, isTrue);
+    expect(find.text('floor-25'), findsOneWidget);
+  });
+}

--- a/test/utils/scroll_floor_index_test.dart
+++ b/test/utils/scroll_floor_index_test.dart
@@ -28,11 +28,13 @@ void main() {
     expect(find.text('floor-0'), findsOneWidget);
     expect(find.text('floor-25'), findsNothing);
 
-    final ok = await ScrollFloorNavigator.scrollToIndex(
+    // Must pump while animateTo runs; awaiting first would deadlock the ticker.
+    final future = ScrollFloorNavigator.scrollToIndex(
       postKeys: keys,
       index: 25,
     );
     await tester.pumpAndSettle();
+    final ok = await future;
 
     expect(ok, isTrue);
     expect(find.text('floor-25'), findsOneWidget);

--- a/test/utils/thread_navigation_test.dart
+++ b/test/utils/thread_navigation_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:s1_app/models/open_scroll_target.dart';
 import 'package:s1_app/models/reading_record.dart';
+import 'package:s1_app/models/thread_destination.dart';
 import 'package:s1_app/models/thread_open_intent.dart';
 import 'package:s1_app/utils/thread_navigation.dart';
 
 ReadingRecord _record({
   int lastReadPage = 1,
   int totalPages = 1,
+  int lastReadFloor = 1,
+  int perPage = 40,
 }) {
   return ReadingRecord(
     tid: '100',
@@ -13,10 +17,10 @@ ReadingRecord _record({
     author: 'author',
     fid: '4',
     lastReadPage: lastReadPage,
-    lastReadFloor: 1,
+    lastReadFloor: lastReadFloor,
     totalPages: totalPages,
     totalReplies: 0,
-    perPage: 40,
+    perPage: perPage,
     lastReadAt: 1,
     firstReadAt: 1,
     readCount: 1,
@@ -24,11 +28,76 @@ ReadingRecord _record({
 }
 
 void main() {
+  group('ThreadRouteCodec', () {
+    test('resume round-trip is bare path', () {
+      const dest = ResumeThread('100');
+      final uri = ThreadRouteCodec.encode(dest);
+      expect(uri.toString(), '/thread/100');
+      expect(ThreadRouteCodec.decode(uri, tid: '100'), isA<ResumeThread>());
+    });
+
+    test('page=1 encodes and decodes as forced page', () {
+      const dest = ThreadPage('100', 1);
+      final uri = ThreadRouteCodec.encode(dest);
+      expect(uri.toString(), '/thread/100?page=1');
+      final decoded = ThreadRouteCodec.decode(uri, tid: '100');
+      expect(decoded, isA<ThreadPage>());
+      expect((decoded as ThreadPage).page, 1);
+    });
+
+    test('page=N round-trip', () {
+      final uri = ThreadRouteCodec.encode(const ThreadPage('100', 5));
+      expect(uri.toString(), '/thread/100?page=5');
+      expect(
+        (ThreadRouteCodec.decode(uri, tid: '100') as ThreadPage).page,
+        5,
+      );
+    });
+
+    test('pid round-trip', () {
+      final uri = ThreadRouteCodec.encode(const ThreadPost('100', '999'));
+      expect(uri.toString(), '/thread/100?pid=999');
+      expect(
+        (ThreadRouteCodec.decode(uri, tid: '100') as ThreadPost).pid,
+        '999',
+      );
+    });
+
+    test('pid wins over page when both present', () {
+      final uri = Uri.parse('/thread/100?page=3&pid=999');
+      final decoded = ThreadRouteCodec.decode(uri, tid: '100');
+      expect(decoded, isA<ThreadPost>());
+      expect((decoded as ThreadPost).pid, '999');
+    });
+
+    test('page with resume=1 stays resume destination', () {
+      final uri = Uri.parse('/thread/100?page=3&resume=1');
+      expect(ThreadRouteCodec.decode(uri, tid: '100'), isA<ResumeThread>());
+      final intent = ThreadRouteCodec.intentFromUri(uri, tid: '100');
+      expect(intent.mode, ThreadOpenMode.resume);
+      expect(intent.page, 3);
+    });
+
+    test('illegal page falls back to resume', () {
+      final uri = Uri.parse('/thread/100?page=abc');
+      expect(ThreadRouteCodec.decode(uri, tid: '100'), isA<ResumeThread>());
+    });
+
+    test('intentFromUri maps forced page=1', () {
+      final intent = ThreadRouteCodec.intentFromUri(
+        Uri.parse('/thread/100?page=1'),
+        tid: '100',
+      );
+      expect(intent.mode, ThreadOpenMode.page);
+      expect(intent.page, 1);
+    });
+  });
+
   group('resolveThreadInitialPage', () {
-    test('A2 explicit initialPage takes priority over reading record', () {
+    test('A2 explicit page takes priority over reading record', () {
       expect(
         resolveThreadInitialPage(
-          intent: const ThreadOpenIntent(initialPage: 5),
+          intent: const ThreadOpenIntent.page(5),
           record: _record(lastReadPage: 3, totalPages: 8),
         ),
         5,
@@ -48,7 +117,7 @@ void main() {
     test('B2 finished thread opens last page when live matches', () {
       expect(
         resolveThreadInitialPage(
-          intent: const ThreadOpenIntent(liveTotalPages: 5),
+          intent: const ThreadOpenIntent.resume(liveTotalPages: 5),
           record: _record(lastReadPage: 5, totalPages: 5),
         ),
         5,
@@ -58,7 +127,7 @@ void main() {
     test('B3 finished thread with new pages opens first new page', () {
       expect(
         resolveThreadInitialPage(
-          intent: const ThreadOpenIntent(liveTotalPages: 7),
+          intent: const ThreadOpenIntent.resume(liveTotalPages: 7),
           record: _record(lastReadPage: 5, totalPages: 5),
         ),
         6,
@@ -72,26 +141,94 @@ void main() {
       );
     });
 
-    test('initialPage 1 does not override record resume', () {
+    test('page=1 forces first page over record resume', () {
       expect(
         resolveThreadInitialPage(
-          intent: const ThreadOpenIntent(initialPage: 1),
+          intent: const ThreadOpenIntent.page(1),
           record: _record(lastReadPage: 4, totalPages: 8),
         ),
+        1,
+      );
+    });
+  });
+
+  group('floorToPageIndex / resolveResumeScrollTarget', () {
+    test('maps absolute floor to page-local index', () {
+      expect(
+        floorToPageIndex(
+          absoluteFloor: 45,
+          page: 2,
+          perPage: 40,
+          postCount: 40,
+        ),
         4,
+      );
+    });
+
+    test('clamps floor below page start to 0', () {
+      expect(
+        floorToPageIndex(
+          absoluteFloor: 1,
+          page: 2,
+          perPage: 40,
+          postCount: 40,
+        ),
+        0,
+      );
+    });
+
+    test('clamps floor past page end to last index', () {
+      expect(
+        floorToPageIndex(
+          absoluteFloor: 999,
+          page: 2,
+          perPage: 40,
+          postCount: 10,
+        ),
+        9,
+      );
+    });
+
+    test('resume with floor → ScrollToFloor', () {
+      final target = resolveResumeScrollTarget(
+        record: _record(lastReadPage: 2, totalPages: 5, lastReadFloor: 45),
+        loadedPage: 2,
+        totalPages: 5,
+      );
+      expect(target, isA<ScrollToFloor>());
+      expect((target as ScrollToFloor).absoluteFloor, 45);
+    });
+
+    test('B3 new page → ScrollToPageTop', () {
+      final target = resolveResumeScrollTarget(
+        record: _record(lastReadPage: 5, totalPages: 5, lastReadFloor: 200),
+        loadedPage: 6,
+        totalPages: 7,
+      );
+      expect(target, isA<ScrollToPageTop>());
+    });
+
+    test('no record → ScrollToPageTop', () {
+      expect(
+        resolveResumeScrollTarget(
+          record: null,
+          loadedPage: 1,
+          totalPages: 1,
+        ),
+        isA<ScrollToPageTop>(),
       );
     });
   });
 
   group('buildThreadDetailPath', () {
-    test('includes page query when target page > 1', () {
+    test('includes page+resume query when target page > 1', () {
       expect(
         buildThreadDetailPath(
           '100',
           record: _record(lastReadPage: 3, totalPages: 8),
           liveTotalPages: 8,
         ),
-        '/thread/100?page=3',
+        '/thread/100?page=3&resume=1',
       );
     });
 
@@ -99,6 +236,29 @@ void main() {
       expect(
         buildThreadDetailPath('100'),
         '/thread/100',
+      );
+    });
+  });
+
+  group('entry path fixtures', () {
+    test('thread_card forced page 1 encodes ?page=1', () {
+      expect(
+        ThreadRouteCodec.encodePath(const ThreadPage('100', 1)),
+        '/thread/100?page=1',
+      );
+    });
+
+    test('favorites/search resume is bare tid', () {
+      expect(
+        ThreadRouteCodec.encodePath(const ResumeThread('100')),
+        '/thread/100',
+      );
+    });
+
+    test('messages/quote/user reply use pid destination', () {
+      expect(
+        ThreadRouteCodec.encodePath(const ThreadPost('100', '55')),
+        '/thread/100?pid=55',
       );
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

统一帖子打开契约为 `resume` / `page(n)`（含 `page=1`）/ `post(pid)`，并通过 `ThreadDestination` + `ThreadRouteCodec` 收口全部 `/thread/` 入口。

- 单一意图源：路由只注入 `ThreadOpenIntent`；`PostNotifier` 负责页决策、B3 与 `OpenScrollTarget`
- 修复 `page=1` 强制页语义；续读防闪页使用 `?page=N&resume=1`
- `locatePostPage` 失败显式上报；pid / 楼级共用索引滚动
- 帖内翻页 `replace` 同步 `?page=`（路由按 tid key，避免整页重挂）
- 楼级阅读进度：可见楼回写 + resume 滚到 `lastReadFloor`（不进 URL）

## Test plan

- [x] `flutter analyze`
- [ ] `flutter test`（导航/打开意图/滚动/进度相关）
- [ ] `dart run scripts/audit_m3.dart --fail-on-error`（若需）
- [ ] 手动：选页第 1 页不误续读；裸 tid 续读到楼；`?pid=` 高亮；翻页 URL 同步

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05723fe9-6101-4449-88b7-463aed5ac78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05723fe9-6101-4449-88b7-463aed5ac78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

