### PR TITLE
feat(haptics): 统一交互震动体系与全覆盖接入

### DIFF
--- a/docs/backup-format-v1.md
+++ b/docs/backup-format-v1.md
@@ -93,6 +93,7 @@ v1 **不使用** JSONL；列表一律为 JSON 数组。
 | `max_images_per_post` | int | 每楼层 inline 图片上限；`0` = 不限 |
 | `image_cache_limit_mb` | int | 磁盘图片缓存上限（MB）；常见 `100` / `256` / `512` |
 | `record_reading_history` | bool | |
+| `haptics_enabled` | bool | 交互震动总开关（默认 `true`；无触感硬件的平台可忽略） |
 | `font_size` | int | |
 | `collapsed_forums` | string[] | 版块 id |
 | `share_image_format` | string | `webp` / `jpeg` / `png`；分享卡片导出图片格式（默认 `webp`） |

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -8,6 +8,7 @@ import '../services/app_local_data.dart';
 import '../services/s1_image_cache.dart';
 import '../services/settings_store.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 
 class AppSettings {
   const AppSettings({
@@ -19,6 +20,7 @@ class AppSettings {
     this.maxImagesPerPost = S1Constants.defaultMaxImagesPerPost,
     this.imageCacheLimitMb = S1Constants.defaultImageCacheLimitMb,
     this.recordReadingHistory = true,
+    this.hapticsEnabled = true,
     this.fontSize = S1Typography.defaultBodySize,
     this.collapsedForums = const {},
     this.shareImageFormat = ShareImageFormat.webp,
@@ -36,6 +38,7 @@ class AppSettings {
   final int maxImagesPerPost;
   final int imageCacheLimitMb;
   final bool recordReadingHistory;
+  final bool hapticsEnabled;
   final int fontSize;
   final Set<String> collapsedForums;
   final ShareImageFormat shareImageFormat;
@@ -55,6 +58,7 @@ class AppSettings {
     int? maxImagesPerPost,
     int? imageCacheLimitMb,
     bool? recordReadingHistory,
+    bool? hapticsEnabled,
     int? fontSize,
     Set<String>? collapsedForums,
     ShareImageFormat? shareImageFormat,
@@ -72,6 +76,7 @@ class AppSettings {
       maxImagesPerPost: maxImagesPerPost ?? this.maxImagesPerPost,
       imageCacheLimitMb: imageCacheLimitMb ?? this.imageCacheLimitMb,
       recordReadingHistory: recordReadingHistory ?? this.recordReadingHistory,
+      hapticsEnabled: hapticsEnabled ?? this.hapticsEnabled,
       fontSize: fontSize ?? this.fontSize,
       collapsedForums: collapsedForums ?? this.collapsedForums,
       shareImageFormat: shareImageFormat ?? this.shareImageFormat,
@@ -94,6 +99,7 @@ class AppSettings {
         other.maxImagesPerPost == maxImagesPerPost &&
         other.imageCacheLimitMb == imageCacheLimitMb &&
         other.recordReadingHistory == recordReadingHistory &&
+        other.hapticsEnabled == hapticsEnabled &&
         other.fontSize == fontSize &&
         _setEquals(other.collapsedForums, collapsedForums) &&
         other.shareImageFormat == shareImageFormat &&
@@ -116,6 +122,7 @@ class AppSettings {
         maxImagesPerPost,
         imageCacheLimitMb,
         recordReadingHistory,
+        hapticsEnabled,
         fontSize,
         Object.hashAllUnordered(collapsedForums),
         shareImageFormat,
@@ -144,15 +151,21 @@ class SettingsNotifier extends Notifier<AppSettings> {
   AppSettings build() {
     if (initial != null) {
       _applyImageCacheLimit(initial!.imageCacheLimitMb);
+      _syncHaptics(initial!.hapticsEnabled);
       return initial!;
     }
     final settings = _loadSettings();
     _applyImageCacheLimit(settings.imageCacheLimitMb);
+    _syncHaptics(settings.hapticsEnabled);
     return settings;
   }
 
   void _applyImageCacheLimit(int limitMb) {
     S1ImageCache.setMaxCacheBytes(limitMb * 1024 * 1024);
+  }
+
+  void _syncHaptics(bool value) {
+    S1Haptics.enabled = value;
   }
 
   SettingsStore? get _effectiveStore {
@@ -168,6 +181,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
 
   void _commit(AppSettings next) {
     if (next == state) return;
+    _syncHaptics(next.hapticsEnabled);
     state = next;
   }
 
@@ -215,6 +229,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
           S1Constants.defaultImageCacheLimitMb,
       recordReadingHistory: settingsStore.get<bool>(
             'recordReadingHistory',
+            defaultValue: true,
+          ) ??
+          true,
+      hapticsEnabled: settingsStore.get<bool>(
+            'hapticsEnabled',
             defaultValue: true,
           ) ??
           true,
@@ -294,6 +313,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
     _persist('recordReadingHistory', value);
   }
 
+  void setHapticsEnabled(bool value) {
+    _commit(state.copyWith(hapticsEnabled: value));
+    _persist('hapticsEnabled', value);
+  }
+
   void setFontSize(int value) {
     _commit(state.copyWith(fontSize: value));
     _persist('fontSize', value);
@@ -347,6 +371,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       maxImagesPerPost: defaults.maxImagesPerPost,
       imageCacheLimitMb: defaults.imageCacheLimitMb,
       recordReadingHistory: defaults.recordReadingHistory,
+      hapticsEnabled: defaults.hapticsEnabled,
       fontSize: defaults.fontSize,
       shareImageFormat: defaults.shareImageFormat,
       sharePixelRatio: defaults.sharePixelRatio,
@@ -361,6 +386,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
     _persist('imageCacheLimitMb', defaults.imageCacheLimitMb);
     _applyImageCacheLimit(defaults.imageCacheLimitMb);
     _persist('recordReadingHistory', defaults.recordReadingHistory);
+    _persist('hapticsEnabled', defaults.hapticsEnabled);
     _persist('fontSize', defaults.fontSize);
     _persist('shareImageFormat', defaults.shareImageFormat.storageKey);
     _persist('sharePixelRatio', defaults.sharePixelRatio);

--- a/lib/screens/blacklist_screen.dart
+++ b/lib/screens/blacklist_screen.dart
@@ -5,6 +5,7 @@ import '../models/blacklist_record.dart';
 import '../providers/blacklist_provider.dart';
 import '../providers/server_blacklist_import_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/s1_snack_bar.dart';
 import '../widgets/s1_confirm_dialog.dart';
 import '../widgets/s1_desktop_scaffold.dart';
@@ -31,19 +32,28 @@ class BlacklistScreen extends ConsumerWidget {
               tooltip: '从网页导入',
               onPressed: importState.isLoading
                   ? null
-                  : () => _importFromWeb(context, ref),
+                  : () {
+                      S1Haptics.medium();
+                      _importFromWeb(context, ref);
+                    },
               icon: const Icon(Icons.cloud_download_outlined),
             ),
             if (entries.isNotEmpty)
               IconButton(
                 tooltip: '清空',
                 icon: const Icon(Icons.delete_sweep_outlined),
-                onPressed: () => _confirmClearAll(context, ref),
+                onPressed: () {
+                  S1Haptics.medium();
+                  _confirmClearAll(context, ref);
+                },
               ),
           ],
         ),
         floatingActionButton: FloatingActionButton.extended(
-          onPressed: () => _showEditor(context, ref),
+          onPressed: () {
+            S1Haptics.selection();
+            _showEditor(context, ref);
+          },
           icon: const Icon(Icons.person_add_disabled_outlined),
           label: const Text('添加'),
         ),
@@ -73,7 +83,7 @@ class BlacklistScreen extends ConsumerWidget {
     } catch (error) {
       if (!context.mounted) return;
       final message = error.toString().replaceFirst('Exception: ', '');
-      S1SnackBar.show(context, message: message);
+      S1SnackBar.error(context, message: message);
       return;
     }
     if (!context.mounted) return;
@@ -88,6 +98,7 @@ class BlacklistScreen extends ConsumerWidget {
       confirmLabel: '导入',
     );
     if (!confirmed || !context.mounted) return;
+    S1Haptics.medium();
     try {
       final result = await notifier.apply(preview);
       if (!context.mounted) return;
@@ -97,7 +108,7 @@ class BlacklistScreen extends ConsumerWidget {
       );
     } catch (error) {
       if (!context.mounted) return;
-      S1SnackBar.show(
+      S1SnackBar.error(
         context,
         message: '导入失败：${error.toString().replaceFirst('Exception: ', '')}',
       );
@@ -255,12 +266,18 @@ class _BlacklistTile extends StatelessWidget {
                 ),
                 IconButton(
                   tooltip: '编辑',
-                  onPressed: onEdit,
+                  onPressed: () {
+                    S1Haptics.selection();
+                    onEdit();
+                  },
                   icon: const Icon(Icons.edit_outlined),
                 ),
                 IconButton(
                   tooltip: '移除',
-                  onPressed: onDelete,
+                  onPressed: () {
+                    S1Haptics.medium();
+                    onDelete();
+                  },
                   icon: Icon(Icons.delete_outline, color: scheme.error),
                 ),
               ],
@@ -354,6 +371,7 @@ class _BlacklistEditorDialogState extends State<_BlacklistEditorDialog> {
       setState(() => _uidError = '请输入用户 UID');
       return;
     }
+    S1Haptics.medium();
     Navigator.of(context).pop(
       _BlacklistDraft(
         uid: uid,
@@ -412,6 +430,7 @@ class _BlacklistEditorDialogState extends State<_BlacklistEditorDialog> {
                   label: const Text('主题列表'),
                   selected: _scopes.contains(BlacklistRecord.scopeThread),
                   onSelected: (selected) {
+                    S1Haptics.selection();
                     setState(() {
                       if (selected) {
                         _scopes.add(BlacklistRecord.scopeThread);
@@ -425,6 +444,7 @@ class _BlacklistEditorDialogState extends State<_BlacklistEditorDialog> {
                   label: const Text('帖内楼层'),
                   selected: _scopes.contains(BlacklistRecord.scopePost),
                   onSelected: (selected) {
+                    S1Haptics.selection();
                     setState(() {
                       if (selected) {
                         _scopes.add(BlacklistRecord.scopePost);
@@ -438,6 +458,7 @@ class _BlacklistEditorDialogState extends State<_BlacklistEditorDialog> {
                   label: const Text('私信'),
                   selected: _scopes.contains(BlacklistRecord.scopePm),
                   onSelected: (selected) {
+                    S1Haptics.selection();
                     setState(() {
                       if (selected) {
                         _scopes.add(BlacklistRecord.scopePm);

--- a/lib/screens/compose_screen.dart
+++ b/lib/screens/compose_screen.dart
@@ -16,6 +16,7 @@ import '../providers/auth_provider.dart';
 import '../providers/compose_provider.dart';
 import '../providers/settings_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/compact_label.dart';
 import '../utils/compose_draft_store.dart';
 import '../utils/compose_img_tags.dart';
@@ -779,6 +780,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
         confirmLabel: '发布',
       );
       if (!mounted || !confirmed) return;
+      S1Haptics.medium();
       setState(() => _isSubmitting = true);
       try {
         final result =
@@ -794,7 +796,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
           setState(() => _allowPop = true);
           context.pop(result);
         } else {
-          S1SnackBar.show(
+          S1SnackBar.error(
             context,
             message: result.error ?? '发帖失败',
             bottomClearance: 72,
@@ -802,7 +804,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
         }
       } catch (e) {
         if (mounted) {
-          S1SnackBar.show(context, message: '$e', bottomClearance: 72);
+          S1SnackBar.error(context, message: '$e', bottomClearance: 72);
         }
       } finally {
         if (mounted) setState(() => _isSubmitting = false);
@@ -837,6 +839,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
         confirmLabel: '确认编辑',
       );
       if (!mounted || !confirmed) return;
+      S1Haptics.medium();
       setState(() => _isSubmitting = true);
       try {
         final result = await ref.read(composeControllerProvider).submitEditPost(
@@ -857,20 +860,20 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
           context.pop(result);
         } else if (result.isConflict) {
           setState(() => _editConflict = true);
-          S1SnackBar.show(
+          S1SnackBar.error(
             context,
             message: result.message ?? '服务器内容已变化，请重新载入',
             bottomClearance: 72,
           );
         } else if (result.isUncertain) {
           setState(() => _editUncertain = true);
-          S1SnackBar.show(
+          S1SnackBar.error(
             context,
             message: result.message ?? '编辑状态不确定，请先核对服务器内容',
             bottomClearance: 72,
           );
         } else {
-          S1SnackBar.show(
+          S1SnackBar.error(
             context,
             message: result.message ?? '编辑失败',
             bottomClearance: 72,
@@ -879,7 +882,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
       } catch (e) {
         if (mounted) {
           setState(() => _editUncertain = true);
-          S1SnackBar.show(context, message: '$e', bottomClearance: 72);
+          S1SnackBar.error(context, message: '$e', bottomClearance: 72);
         }
       } finally {
         if (mounted) setState(() => _isSubmitting = false);
@@ -902,6 +905,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
       return;
     }
 
+    S1Haptics.medium();
     setState(() => _isSubmitting = true);
 
     try {
@@ -922,7 +926,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
           setState(() => _allowPop = true);
           context.pop(result);
         } else {
-          S1SnackBar.show(
+          S1SnackBar.error(
             context,
             message: result.error ?? '回复失败',
             bottomClearance: 72,
@@ -931,7 +935,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
       }
     } catch (e) {
       if (mounted) {
-        S1SnackBar.show(context, message: '$e', bottomClearance: 72);
+        S1SnackBar.error(context, message: '$e', bottomClearance: 72);
       }
     } finally {
       if (mounted) setState(() => _isSubmitting = false);

--- a/lib/screens/dark_room_screen.dart
+++ b/lib/screens/dark_room_screen.dart
@@ -6,6 +6,7 @@ import '../config/api_config.dart';
 import '../models/dark_room_entry.dart';
 import '../models/user.dart';
 import '../providers/dark_room_provider.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/web_avatar.dart';
@@ -40,7 +41,9 @@ class DarkRoomScreen extends ConsumerWidget {
           ),
           error: (error, stack) => S1ErrorView(
             error: error,
-            onRetry: () => ref.read(darkRoomProvider.notifier).refresh(),
+            onRetry: () => S1Haptics.wrapRefresh(
+              () => ref.read(darkRoomProvider.notifier).refresh(),
+            ),
             onLogin: () => context.push('/login'),
           ),
           data: (state) {
@@ -48,7 +51,9 @@ class DarkRoomScreen extends ConsumerWidget {
               return const _EmptyDarkRoom();
             }
             return RefreshIndicator(
-              onRefresh: () => ref.read(darkRoomProvider.notifier).refresh(),
+              onRefresh: () => S1Haptics.wrapRefresh(
+                () => ref.read(darkRoomProvider.notifier).refresh(),
+              ),
               child: ListView.builder(
                 padding: const EdgeInsets.fromLTRB(12, 8, 12, 24),
                 itemCount: state.items.length + (state.hasMore ? 1 : 0),

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/favorite_confirm_dialog.dart';
 import '../utils/format_utils.dart';
 import '../utils/s1_snack_bar.dart';
 import '../utils/thread_navigation.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/pagination_bar.dart';
 import '../widgets/s1_error_view.dart';
@@ -155,8 +156,9 @@ class _FavoriteListBody extends ConsumerWidget {
       ),
       error: (e, st) => S1ErrorView(
         error: e,
-        onRetry: () =>
-            ref.read(favoriteListProvider(segment).notifier).refresh(),
+        onRetry: () => S1Haptics.wrapRefresh(
+          () => ref.read(favoriteListProvider(segment).notifier).refresh(),
+        ),
         onLogin: () => context.push('/login'),
       ),
       data: (state) => Column(
@@ -170,14 +172,14 @@ class _FavoriteListBody extends ConsumerWidget {
                   .read(favoriteListProvider(segment).notifier)
                   .goToPage(page),
               pageBuilder: (context, scrollController) => RefreshIndicator(
-                onRefresh: () async {
+                onRefresh: () => S1Haptics.wrapRefresh(() async {
                   await ref
                       .read(favoriteListProvider(segment).notifier)
                       .refresh();
                   await ref
                       .read(favoriteMembershipProvider.notifier)
                       .ensureSynced();
-                },
+                }),
                 child: state.items.isEmpty
                     ? ListView(
                         controller: scrollController,

--- a/lib/screens/forum_list_screen.dart
+++ b/lib/screens/forum_list_screen.dart
@@ -23,6 +23,7 @@ import '../utils/forum_list_layout.dart';
 import '../models/thread_open_intent.dart';
 import '../models/thread_destination.dart';
 import '../utils/thread_navigation.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/thread_open_intent_scope.dart';
 
 class ForumListScreen extends ConsumerStatefulWidget {
@@ -155,9 +156,11 @@ class _ForumListScreenState extends ConsumerState<ForumListScreen> {
                       ),
                       error: (e, st) => S1ErrorView(
                         error: e,
-                        onRetry: () => ref
-                            .read(threadListProvider(widget.fid).notifier)
-                            .refresh(),
+                        onRetry: () => S1Haptics.wrapRefresh(
+                          () => ref
+                              .read(threadListProvider(widget.fid).notifier)
+                              .refresh(),
+                        ),
                         onLogin: () => context.push('/login'),
                       ),
                       data: (state) => _ForumThreadList(
@@ -188,9 +191,11 @@ class _ForumListScreenState extends ConsumerState<ForumListScreen> {
                         ),
                         error: (e, st) => S1ErrorView(
                           error: e,
-                          onRetry: () => ref
-                              .read(threadListProvider(widget.fid).notifier)
-                              .refresh(),
+                          onRetry: () => S1Haptics.wrapRefresh(
+                            () => ref
+                                .read(threadListProvider(widget.fid).notifier)
+                                .refresh(),
+                          ),
                           onLogin: () => context.push('/login'),
                         ),
                         data: (state) => _ForumThreadList(
@@ -304,8 +309,9 @@ class _ForumThreadList extends ConsumerWidget {
               pageBuilder: (context, scrollController) => Scrollbar(
                 controller: scrollController,
                 child: RefreshIndicator(
-                  onRefresh: () =>
-                      ref.read(threadListProvider(fid).notifier).refresh(),
+                  onRefresh: () => S1Haptics.wrapRefresh(
+                    () => ref.read(threadListProvider(fid).notifier).refresh(),
+                  ),
                   child: state.threads.isEmpty
                       ? ListView(
                           controller: scrollController,

--- a/lib/screens/friends_screen.dart
+++ b/lib/screens/friends_screen.dart
@@ -6,6 +6,7 @@ import '../config/api_config.dart';
 import '../models/friend_summary.dart';
 import '../providers/auth_provider.dart';
 import '../providers/friend_list_provider.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/web_avatar.dart';
@@ -44,7 +45,9 @@ class FriendsScreen extends ConsumerWidget {
           ),
           error: (error, stack) => S1ErrorView(
             error: error,
-            onRetry: () => ref.read(friendListProvider.notifier).refresh(),
+            onRetry: () => S1Haptics.wrapRefresh(
+              () => ref.read(friendListProvider.notifier).refresh(),
+            ),
             onLogin: () => context.push('/login'),
           ),
           data: (result) {
@@ -52,7 +55,9 @@ class FriendsScreen extends ConsumerWidget {
               return const _EmptyFriends();
             }
             return RefreshIndicator(
-              onRefresh: () => ref.read(friendListProvider.notifier).refresh(),
+              onRefresh: () => S1Haptics.wrapRefresh(
+                () => ref.read(friendListProvider.notifier).refresh(),
+              ),
               child: ListView.separated(
                 padding: const EdgeInsets.symmetric(vertical: 8),
                 itemCount: result.items.length,
@@ -131,6 +136,7 @@ class _FriendTile extends StatelessWidget {
         style: textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
       ),
       onTap: () {
+        S1Haptics.selection();
         final name = Uri.encodeComponent(friend.username);
         context.push('/user-space/${friend.uid}?username=$name');
       },

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import '../providers/settings_provider.dart';
 import '../models/forum_category.dart';
 import '../models/notice_item.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/s1_content_width.dart';
@@ -172,6 +173,7 @@ class _HomeScreenBodyState extends ConsumerState<_HomeScreenBody> {
           : NavigationBar(
               selectedIndex: selectedTab,
               onDestinationSelected: (index) {
+                S1Haptics.selection();
                 if (selectedTab == 2 && index != 2) {
                   ref.read(messagesSegmentProvider.notifier).select(0);
                 }
@@ -234,12 +236,15 @@ class _ForumTab extends ConsumerWidget {
       ),
       error: (e, st) => S1ErrorView(
         error: e,
-        onRetry: () => ref.read(forumListProvider.notifier).refresh(),
+        onRetry: () => S1Haptics.wrapRefresh(
+          () => ref.read(forumListProvider.notifier).refresh(),
+        ),
         onLogin: () => context.push('/login'),
       ),
       data: (categories) {
-        Future<void> refresh() =>
-            ref.read(forumListProvider.notifier).refresh();
+        Future<void> refresh() => S1Haptics.wrapRefresh(
+              () => ref.read(forumListProvider.notifier).refresh(),
+            );
 
         if (categories.isEmpty) {
           final scheme = Theme.of(context).colorScheme;

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../config/login_security_questions.dart';
 import '../providers/auth_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
@@ -36,6 +37,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   Future<void> _handleLogin() async {
+    S1Haptics.medium();
     final username = _usernameController.text.trim();
     final password = _passwordController.text;
     final answer = _answerController.text.trim();
@@ -44,6 +46,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       setState(() {
         _errorMessage = '用户名和密码不能为空';
       });
+      S1Haptics.heavy();
       return;
     }
 
@@ -51,6 +54,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       setState(() {
         _errorMessage = '请填写安全提问的答案';
       });
+      S1Haptics.heavy();
       return;
     }
 
@@ -71,6 +75,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     if (error == null) {
       context.go('/');
     } else {
+      S1Haptics.heavy();
       setState(() {
         _isLoading = false;
         _errorMessage = error;

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -7,6 +7,7 @@ import '../providers/messages_segment_provider.dart';
 import '../providers/notice_list_provider.dart';
 import '../providers/pm_list_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/thread_navigation.dart';
 import '../widgets/notice_list_tile.dart';
 import '../widgets/pagination_bar.dart';
@@ -48,6 +49,7 @@ class _MessagesScreenState extends ConsumerState<MessagesScreen> {
             ],
             selected: {_segment},
             onSelectionChanged: (value) {
+              S1Haptics.selection();
               final next = value.first;
               setState(() => _segment = next);
               ref.read(messagesSegmentProvider.notifier).select(next);
@@ -79,11 +81,15 @@ class _PmListBody extends ConsumerWidget {
       ),
       error: (e, st) => S1ErrorView(
         error: e,
-        onRetry: () => ref.read(pmListProvider.notifier).refresh(),
+        onRetry: () => S1Haptics.wrapRefresh(
+          () => ref.read(pmListProvider.notifier).refresh(),
+        ),
         onLogin: () => context.push('/login'),
       ),
       data: (state) => RefreshIndicator(
-        onRefresh: () => ref.read(pmListProvider.notifier).refresh(),
+        onRefresh: () => S1Haptics.wrapRefresh(
+          () => ref.read(pmListProvider.notifier).refresh(),
+        ),
         child: state.items.isEmpty
             ? ListView(
                 children: const [
@@ -133,7 +139,9 @@ class _NoticeListBody extends ConsumerWidget {
       ),
       error: (e, st) => S1ErrorView(
         error: e,
-        onRetry: () => ref.read(noticeListProvider.notifier).refresh(),
+        onRetry: () => S1Haptics.wrapRefresh(
+          () => ref.read(noticeListProvider.notifier).refresh(),
+        ),
         onLogin: () => context.push('/login'),
       ),
       data: (state) => Column(
@@ -154,6 +162,7 @@ class _NoticeListBody extends ConsumerWidget {
               selected: {state.feed},
               showSelectedIcon: false,
               onSelectionChanged: (value) {
+                S1Haptics.selection();
                 final feed = value.first;
                 ref.read(noticeFeedSelectionProvider.notifier).select(feed);
                 ref.read(noticeListProvider.notifier).selectFeed(feed);
@@ -171,8 +180,9 @@ class _NoticeListBody extends ConsumerWidget {
               onPageChanged: (page) =>
                   ref.read(noticeListProvider.notifier).goToPage(page),
               pageBuilder: (context, scrollController) => RefreshIndicator(
-                onRefresh: () =>
-                    ref.read(noticeListProvider.notifier).refresh(),
+                onRefresh: () => S1Haptics.wrapRefresh(
+                  () => ref.read(noticeListProvider.notifier).refresh(),
+                ),
                 child: state.items.isEmpty
                     ? ListView(
                         controller: scrollController,

--- a/lib/screens/pm_conversation_screen.dart
+++ b/lib/screens/pm_conversation_screen.dart
@@ -8,6 +8,7 @@ import '../models/private_message_item.dart';
 import '../providers/pm_conversation_provider.dart';
 import '../providers/settings_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/window_size.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/pagination_bar.dart';
@@ -329,7 +330,9 @@ class _PmConversationScreenState extends ConsumerState<PmConversationScreen> {
           ),
           error: (error, stack) => S1ErrorView(
             error: error,
-            onRetry: () => ref.read(provider.notifier).refresh(),
+            onRetry: () => S1Haptics.wrapRefresh(
+              () => ref.read(provider.notifier).refresh(),
+            ),
             onLogin: () => context.push('/login'),
           ),
           data: (state) {
@@ -359,8 +362,9 @@ class _PmConversationScreenState extends ConsumerState<PmConversationScreen> {
                               : double.infinity,
                         ),
                         child: RefreshIndicator(
-                          onRefresh: () =>
-                              ref.read(provider.notifier).refresh(),
+                          onRefresh: () => S1Haptics.wrapRefresh(
+                            () => ref.read(provider.notifier).refresh(),
+                          ),
                           child: state.items.isEmpty
                               ? ListView(
                                   controller: scrollController,

--- a/lib/screens/reading_history_screen.dart
+++ b/lib/screens/reading_history_screen.dart
@@ -5,6 +5,7 @@ import '../models/reading_record.dart';
 import '../providers/forum_name_provider.dart';
 import '../providers/reading_history_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/format_utils.dart';
 import '../utils/thread_navigation.dart';
 import '../widgets/s1_confirm_dialog.dart';
@@ -134,7 +135,10 @@ class _HistoryTile extends ConsumerWidget {
         color: S1Surface.card(scheme),
         shape: S1Shape.cardShape,
         child: InkWell(
-          onTap: () => _open(context),
+          onTap: () {
+            S1Haptics.selection();
+            _open(context);
+          },
           borderRadius: S1Shape.medium,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -8,6 +8,7 @@ import '../models/user.dart';
 import '../providers/search_provider.dart';
 import '../providers/user_profile_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/thread_navigation.dart';
 import '../widgets/s1_error_view.dart';
 import '../widgets/pagination_bar.dart';
@@ -344,9 +345,12 @@ class _ForumHitTile extends StatelessWidget {
       shape: S1Shape.cardShape,
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => context.push(
-          ThreadRouteCodec.encodePath(ResumeThread(hit.tid)),
-        ),
+        onTap: () {
+          S1Haptics.selection();
+          context.push(
+            ThreadRouteCodec.encodePath(ResumeThread(hit.tid)),
+          );
+        },
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -446,6 +450,7 @@ class _UserHitTile extends ConsumerWidget {
         ),
         trailing: const Icon(Icons.chevron_right),
         onTap: () {
+          S1Haptics.selection();
           showUserProfileSheet(
             context,
             future: ref.read(userProfileProvider(hit.uid).future),

--- a/lib/services/backup/s1_backup_codec.dart
+++ b/lib/services/backup/s1_backup_codec.dart
@@ -151,6 +151,7 @@ class S1BackupSettingsMapper {
     'maxImagesPerPost': 'max_images_per_post',
     'imageCacheLimitMb': 'image_cache_limit_mb',
     'recordReadingHistory': 'record_reading_history',
+    'hapticsEnabled': 'haptics_enabled',
     'fontSize': 'font_size',
     'collapsedForums': 'collapsed_forums',
     'shareImageFormat': 'share_image_format',

--- a/lib/services/backup/s1_backup_service.dart
+++ b/lib/services/backup/s1_backup_service.dart
@@ -63,6 +63,7 @@ class S1BackupService {
     appSettings.putIfAbsent('maxImagesPerPost', () => 10);
     appSettings.putIfAbsent('imageCacheLimitMb', () => 256);
     appSettings.putIfAbsent('recordReadingHistory', () => true);
+    appSettings.putIfAbsent('hapticsEnabled', () => true);
     appSettings.putIfAbsent('fontSize', () => 14);
     appSettings.putIfAbsent('collapsedForums', () => <String>[]);
     appSettings.putIfAbsent('shareImageFormat', () => 'webp');

--- a/lib/services/post_share_service.dart
+++ b/lib/services/post_share_service.dart
@@ -1,12 +1,12 @@
 // ignore_for_file: unawaited_futures
 
 import 'dart:async';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gal/gal.dart';
 import 'package:path/path.dart' as p;
@@ -21,6 +21,7 @@ import '../utils/bbcode_parser.dart';
 import '../utils/share_native_image_encoder.dart';
 import '../utils/share_rgba_flatten.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../widgets/share_card.dart';
 import '../widgets/s1_click_region.dart';
 import '../widgets/web_image_stub.dart'
@@ -104,7 +105,7 @@ class _SharePreviewSheetState extends ConsumerState<_SharePreviewSheet> {
 
   Future<void> _captureAndShare() async {
     if (_state != _FooterState.idle) return;
-    HapticFeedback.mediumImpact();
+    S1Haptics.medium();
     setState(() => _state = _FooterState.capturing);
 
     final bytes = await _captureBytes();
@@ -133,7 +134,7 @@ class _SharePreviewSheetState extends ConsumerState<_SharePreviewSheet> {
 
   Future<void> _captureAndSave() async {
     if (_state != _FooterState.idle) return;
-    HapticFeedback.mediumImpact();
+    S1Haptics.medium();
     setState(() => _state = _FooterState.capturing);
 
     final bytes = await _captureBytes();

--- a/lib/theme/s1_haptics.dart
+++ b/lib/theme/s1_haptics.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+/// Semantic haptic tokens for S1er interactions.
+///
+/// Gate with [enabled] (synced from settings). Unsupported platforms no-op.
+abstract class S1Haptics {
+  /// Master switch; updated by [SettingsNotifier].
+  static bool enabled = true;
+
+  /// Browse / switch / pick (high frequency).
+  static void selection() {
+    if (!enabled) return;
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  /// Light confirm: copy, pull-to-refresh, non-destructive soft actions.
+  static void light() {
+    if (!enabled) return;
+    unawaited(HapticFeedback.lightImpact());
+  }
+
+  /// Primary write / emphasized gesture.
+  static void medium() {
+    if (!enabled) return;
+    unawaited(HapticFeedback.mediumImpact());
+  }
+
+  /// Destructive confirm or clear error path.
+  static void heavy() {
+    if (!enabled) return;
+    unawaited(HapticFeedback.heavyImpact());
+  }
+
+  /// Fire [selection] then [callback] (null-safe).
+  static VoidCallback? wrapTap(VoidCallback? callback) {
+    if (callback == null) return null;
+    return () {
+      selection();
+      callback();
+    };
+  }
+
+  /// Fire [medium] then [callback] (null-safe).
+  static VoidCallback? wrapLongPress(VoidCallback? callback) {
+    if (callback == null) return null;
+    return () {
+      medium();
+      callback();
+    };
+  }
+
+  /// Pull-to-refresh / retry: [light] then [refresh].
+  static Future<void> wrapRefresh(Future<void> Function() refresh) async {
+    light();
+    await refresh();
+  }
+}

--- a/lib/utils/s1_snack_bar.dart
+++ b/lib/utils/s1_snack_bar.dart
@@ -1,6 +1,14 @@
 import 'package:flutter/material.dart';
 
+import '../theme/s1_haptics.dart';
 import '../widgets/s1_fab_layout.dart';
+
+/// Optional haptic paired with a SnackBar (avoid doubling a prior gesture).
+enum S1SnackBarFeedback {
+  none,
+  success,
+  error,
+}
 
 /// 全局 SnackBar：浮动在分页栏上方，不顶起内容区 FAB。
 abstract class S1SnackBar {
@@ -13,7 +21,17 @@ abstract class S1SnackBar {
     VoidCallback? onAction,
     Duration duration = const Duration(seconds: 4),
     double? bottomClearance,
+    S1SnackBarFeedback feedback = S1SnackBarFeedback.none,
   }) {
+    switch (feedback) {
+      case S1SnackBarFeedback.success:
+        S1Haptics.light();
+      case S1SnackBarFeedback.error:
+        S1Haptics.heavy();
+      case S1SnackBarFeedback.none:
+        break;
+    }
+
     final padding = MediaQuery.paddingOf(context);
     final clearance = bottomClearance ?? S1FabLayout.snackBarClearance;
 
@@ -35,6 +53,46 @@ abstract class S1SnackBar {
               )
             : null,
       ),
+    );
+  }
+
+  /// Success without a preceding write-gesture haptic.
+  static void success(
+    BuildContext context, {
+    required String message,
+    String? actionLabel,
+    VoidCallback? onAction,
+    Duration duration = const Duration(seconds: 4),
+    double? bottomClearance,
+  }) {
+    show(
+      context,
+      message: message,
+      actionLabel: actionLabel,
+      onAction: onAction,
+      duration: duration,
+      bottomClearance: bottomClearance,
+      feedback: S1SnackBarFeedback.success,
+    );
+  }
+
+  /// Explicit error path (login fail, API error after gesture, etc.).
+  static void error(
+    BuildContext context, {
+    required String message,
+    String? actionLabel,
+    VoidCallback? onAction,
+    Duration duration = const Duration(seconds: 4),
+    double? bottomClearance,
+  }) {
+    show(
+      context,
+      message: message,
+      actionLabel: actionLabel,
+      onAction: onAction,
+      duration: duration,
+      bottomClearance: bottomClearance,
+      feedback: S1SnackBarFeedback.error,
     );
   }
 }

--- a/lib/widgets/app_bar_more_menu.dart
+++ b/lib/widgets/app_bar_more_menu.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../theme/s1_haptics.dart';
 import '../utils/s1_snack_bar.dart';
 import 's1_menu.dart';
 
@@ -43,12 +44,18 @@ class AppBarMoreMenu extends StatelessWidget {
       menuChildren: [
         if (onRefresh != null)
           s1MenuItem(
-            onPressed: onRefresh,
+            onPressed: () {
+              S1Haptics.light();
+              onRefresh!();
+            },
             icon: Icons.refresh,
             label: '刷新',
           ),
         s1MenuItem(
-          onPressed: () => _openBrowser(context),
+          onPressed: () {
+            S1Haptics.selection();
+            _openBrowser(context);
+          },
           icon: Icons.open_in_browser,
           label: '通过浏览器打开',
         ),

--- a/lib/widgets/compose_emoticon_panel.dart
+++ b/lib/widgets/compose_emoticon_panel.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../models/emoticon_catalog.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import 'emoticon_widget.dart';
 
 /// 回复页表情面板：键盘高度的 input accessory（与底部操作栏一体），
@@ -46,7 +46,7 @@ class _ComposeEmoticonPanelState extends State<ComposeEmoticonPanel>
   }
 
   void _pick(String entity) {
-    HapticFeedback.selectionClick();
+    S1Haptics.selection();
     widget.onSelect(entity);
   }
 

--- a/lib/widgets/daily_sign_card.dart
+++ b/lib/widgets/daily_sign_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/attendance_result.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 
 /// 每日签到卡片：纯展示，由调用方传入状态与回调。
 class DailySignCard extends StatelessWidget {
@@ -68,7 +69,12 @@ class DailySignCard extends StatelessWidget {
               Icon(Icons.done, color: scheme.primary)
             else
               FilledButton(
-                onPressed: isSubmitting ? null : onSign,
+                onPressed: isSubmitting
+                    ? null
+                    : () {
+                        S1Haptics.medium();
+                        onSign();
+                      },
                 child: isSubmitting
                     ? SizedBox(
                         width: 18,

--- a/lib/widgets/favorite_bookmark_button.dart
+++ b/lib/widgets/favorite_bookmark_button.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../models/favorite_item.dart';
 import '../providers/auth_provider.dart';
 import '../providers/favorite_membership_provider.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/s1_snack_bar.dart';
 import 'favorite_confirm_dialog.dart';
 
@@ -49,6 +50,7 @@ class _FavoriteBookmarkButtonState
       if (!confirmed || !mounted) return;
     }
 
+    S1Haptics.medium();
     setState(() => _busy = true);
 
     final notifier = ref.read(favoriteMembershipProvider.notifier);
@@ -60,7 +62,7 @@ class _FavoriteBookmarkButtonState
     setState(() => _busy = false);
 
     if (error != null) {
-      S1SnackBar.show(context, message: error);
+      S1SnackBar.error(context, message: error);
     }
   }
 

--- a/lib/widgets/notice_list_tile.dart
+++ b/lib/widgets/notice_list_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/notice_item.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/format_utils.dart';
 import 'web_avatar.dart';
 
@@ -38,7 +39,7 @@ class NoticeListTile extends StatelessWidget {
       color: S1Surface.card(scheme),
       shape: S1Shape.cardShape,
       child: ListTile(
-        onTap: item.canNavigate ? onTap : null,
+        onTap: item.canNavigate ? S1Haptics.wrapTap(onTap) : null,
         shape: S1Shape.cardShape,
         leading: WebAvatar(
           url: item.avatarUrl,

--- a/lib/widgets/page_picker_sheet.dart
+++ b/lib/widgets/page_picker_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/window_size.dart';
 import 's1_adaptive_sheet.dart';
 
@@ -357,7 +358,12 @@ class _PageEntryTile extends StatelessWidget {
               color: scheme.onSurfaceVariant.withValues(alpha: S1Alpha.strong),
               size: 18,
             ),
-      onTap: isCurrent ? null : () => onSelected(page),
+      onTap: isCurrent
+          ? null
+          : () {
+              S1Haptics.selection();
+              onSelected(page);
+            },
     );
   }
 }

--- a/lib/widgets/pagination_bar.dart
+++ b/lib/widgets/pagination_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/compact_label.dart';
 import 'page_picker_sheet.dart';
 
@@ -38,6 +39,7 @@ class _PaginationBarState extends State<PaginationBar> {
     if (_isLoading || page == widget.currentPage) return;
     if (page < 1 || page > widget.totalPages) return;
 
+    S1Haptics.selection();
     setState(() => _isLoading = true);
     try {
       await widget.onPageChanged(page);
@@ -47,6 +49,7 @@ class _PaginationBarState extends State<PaginationBar> {
   }
 
   void _showPagePicker() {
+    S1Haptics.selection();
     showPagePickerSheet(
       context: context,
       currentPage: widget.currentPage,

--- a/lib/widgets/pm_list_tile.dart
+++ b/lib/widgets/pm_list_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/private_message_item.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/format_utils.dart';
 import 'web_avatar.dart';
 
@@ -27,7 +28,7 @@ class PmListTile extends StatelessWidget {
       color: S1Surface.card(scheme),
       shape: S1Shape.cardShape,
       child: ListTile(
-        onTap: onTap,
+        onTap: S1Haptics.wrapTap(onTap),
         shape: S1Shape.cardShape,
         leading: WebAvatar(
           url: item.avatarUrl,

--- a/lib/widgets/poll_card.dart
+++ b/lib/widgets/poll_card.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../providers/poll_vote_provider.dart';
 import '../providers/post_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/format_utils.dart';
 import '../utils/poll_bar_color.dart';
 import '../utils/s1_snack_bar.dart';
@@ -70,6 +71,7 @@ class _PollCardState extends ConsumerState<PollCard> {
       return;
     }
 
+    S1Haptics.medium();
     setState(() => _submitting = true);
     try {
       final error = await ref
@@ -78,7 +80,7 @@ class _PollCardState extends ConsumerState<PollCard> {
       if (!mounted) return;
 
       if (error != null) {
-        S1SnackBar.show(context, message: error);
+        S1SnackBar.error(context, message: error);
         return;
       }
 
@@ -94,7 +96,7 @@ class _PollCardState extends ConsumerState<PollCard> {
       await ref.read(postProvider(widget.tid).notifier).refresh();
     } catch (e) {
       if (!mounted) return;
-      S1SnackBar.show(context, message: '投票失败: $e');
+      S1SnackBar.error(context, message: '投票失败: $e');
     } finally {
       if (mounted) setState(() => _submitting = false);
     }

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../providers/thread_rate_logs_provider.dart';
 import '../providers/user_profile_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
 import '../utils/post_image_index_counter.dart';
@@ -158,6 +159,7 @@ class _PostItemState extends ConsumerState<PostItem>
     final plain = PostPlainText.fromMessage(widget.post.message);
     await Clipboard.setData(ClipboardData(text: plain));
     if (!context.mounted) return;
+    S1Haptics.light();
     S1SnackBar.show(context, message: '已复制');
   }
 

--- a/lib/widgets/rate_dialog.dart
+++ b/lib/widgets/rate_dialog.dart
@@ -5,6 +5,7 @@ import '../models/rate_form.dart';
 import '../providers/rate_action_provider.dart';
 import '../providers/thread_rate_logs_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/s1_snack_bar.dart';
 
 /// 打开评分弹窗：预取表单 → 填写 → 提交 → 刷新评分历史。
@@ -76,6 +77,7 @@ class _RateDialogState extends ConsumerState<_RateDialog> {
       return;
     }
 
+    S1Haptics.medium();
     setState(() => _submitting = true);
     try {
       final error = await ref
@@ -89,7 +91,7 @@ class _RateDialogState extends ConsumerState<_RateDialog> {
       if (!mounted) return;
 
       if (error != null) {
-        S1SnackBar.show(context, message: error);
+        S1SnackBar.error(context, message: error);
         return;
       }
 
@@ -102,7 +104,7 @@ class _RateDialogState extends ConsumerState<_RateDialog> {
       S1SnackBar.show(context, message: '评分成功');
     } catch (e) {
       if (!mounted) return;
-      S1SnackBar.show(context, message: '评分失败: $e');
+      S1SnackBar.error(context, message: '评分失败: $e');
     } finally {
       if (mounted) setState(() => _submitting = false);
     }

--- a/lib/widgets/report_dialog.dart
+++ b/lib/widgets/report_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/report_form.dart';
 import '../providers/report_action_provider.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/s1_snack_bar.dart';
 
 Future<void> showReportDialog(
@@ -66,6 +67,7 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
     if (_options == null || _options!.hasError || _submitting) return;
     if (!(_formKey.currentState?.validate() ?? false)) return;
 
+    S1Haptics.medium();
     setState(() => _submitting = true);
     final error =
         await ref.read(reportActionControllerProvider(widget.target)).submit(
@@ -76,7 +78,7 @@ class _ReportDialogState extends ConsumerState<_ReportDialog> {
     if (!mounted) return;
     setState(() => _submitting = false);
     if (error != null) {
-      S1SnackBar.show(context, message: error);
+      S1SnackBar.error(context, message: error);
       return;
     }
     Navigator.of(context).pop();

--- a/lib/widgets/s1_click_region.dart
+++ b/lib/widgets/s1_click_region.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 
+import '../theme/s1_haptics.dart';
+
 /// Clickable region without Material splash; shows hand cursor on desktop/web.
 class S1ClickRegion extends StatelessWidget {
   const S1ClickRegion({
@@ -8,6 +10,7 @@ class S1ClickRegion extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.behavior,
+    this.haptic = true,
   });
 
   final Widget child;
@@ -15,15 +18,22 @@ class S1ClickRegion extends StatelessWidget {
   final VoidCallback? onLongPress;
   final HitTestBehavior? behavior;
 
+  /// When true (default), tap fires [S1Haptics.selection] and long-press
+  /// fires [S1Haptics.medium].
+  final bool haptic;
+
   @override
   Widget build(BuildContext context) {
+    final tap = haptic ? S1Haptics.wrapTap(onTap) : onTap;
+    final longPress =
+        haptic ? S1Haptics.wrapLongPress(onLongPress) : onLongPress;
     return MouseRegion(
       cursor: onTap == null && onLongPress == null
           ? MouseCursor.defer
           : SystemMouseCursors.click,
       child: GestureDetector(
-        onTap: onTap,
-        onLongPress: onLongPress,
+        onTap: tap,
+        onLongPress: longPress,
         behavior: behavior,
         child: child,
       ),

--- a/lib/widgets/s1_confirm_dialog.dart
+++ b/lib/widgets/s1_confirm_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../theme/s1_haptics.dart';
+
 /// MD3 确认弹窗：低强调 [TextButton]「取消」+ [FilledButton] 确认。
 ///
 /// [destructive] 为 true 时确认按钮使用 [ColorScheme.error] / [ColorScheme.onError]。
@@ -22,7 +24,14 @@ Future<bool> showS1ConfirmDialog(
           child: const Text('取消'),
         ),
         FilledButton(
-          onPressed: () => Navigator.of(ctx).pop(true),
+          onPressed: () {
+            if (destructive) {
+              S1Haptics.heavy();
+            } else {
+              S1Haptics.medium();
+            }
+            Navigator.of(ctx).pop(true);
+          },
           style: destructive
               ? FilledButton.styleFrom(
                   backgroundColor: scheme.error,

--- a/lib/widgets/s1_desktop_scaffold.dart
+++ b/lib/widgets/s1_desktop_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
+import '../theme/s1_haptics.dart';
 import '../utils/window_size.dart';
 
 /// Wraps a page with a persistent [NavigationRail] on medium+ screens.
@@ -41,6 +42,7 @@ class S1DesktopScaffold extends ConsumerWidget {
     );
 
     void selectDestination(int index) {
+      S1Haptics.selection();
       final tab = isLoggedIn
           ? const ['forum', 'search', 'messages', 'profile'][index]
           : const ['forum', 'profile'][index];

--- a/lib/widgets/s1_fab_layout.dart
+++ b/lib/widgets/s1_fab_layout.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 
 /// 可滚动区域的偏移与视口尺寸，供「返回顶部 / 下一楼」等 FAB 判定使用。
 class S1ScrollMetrics {
@@ -304,7 +304,7 @@ class _NavActionButtonState extends State<_NavActionButton> {
   bool _longPressActivated = false;
 
   void _onTap() {
-    HapticFeedback.selectionClick();
+    S1Haptics.selection();
     if (_longPressActivated) {
       setState(() => _longPressActivated = false);
     }
@@ -312,7 +312,7 @@ class _NavActionButtonState extends State<_NavActionButton> {
   }
 
   void _onLongPress() {
-    HapticFeedback.mediumImpact();
+    S1Haptics.medium();
     if (widget.longPressIcon != null) {
       setState(() => _longPressActivated = true);
     }

--- a/lib/widgets/s1_swipe_pagination.dart
+++ b/lib/widgets/s1_swipe_pagination.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../theme/s1_haptics.dart';
 import '../utils/scroll_motion.dart';
 import 's1_fab_layout.dart';
 
@@ -173,6 +174,7 @@ class S1SwipePaginationState extends State<S1SwipePagination> {
       _isPaging = true;
       _pendingPage = page;
     });
+    S1Haptics.selection();
 
     try {
       await widget.onPageChanged(page);

--- a/lib/widgets/settings/browsing_settings_section.dart
+++ b/lib/widgets/settings/browsing_settings_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/settings_provider.dart';
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 import 'settings_section_header.dart';
 
 class BrowsingSettingsSection extends ConsumerWidget {
@@ -13,8 +14,14 @@ class BrowsingSettingsSection extends ConsumerWidget {
     final recordReadingHistory = ref.watch(
       settingsProvider.select((settings) => settings.recordReadingHistory),
     );
+    final hapticsEnabled = ref.watch(
+      settingsProvider.select((settings) => settings.hapticsEnabled),
+    );
     final notifier = ref.read(settingsProvider.notifier);
     final scheme = Theme.of(context).colorScheme;
+    final subtitleStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: scheme.onSurfaceVariant,
+        );
 
     return Card(
       elevation: 0,
@@ -31,12 +38,38 @@ class BrowsingSettingsSection extends ConsumerWidget {
               title: const Text('记录阅读历史'),
               subtitle: Text(
                 '关闭后不再写入新的阅读进度与阅读历史。已有记录不会自动删除。',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                    ),
+                style: subtitleStyle,
               ),
               value: recordReadingHistory,
-              onChanged: notifier.setRecordReadingHistory,
+              onChanged: (value) {
+                S1Haptics.selection();
+                notifier.setRecordReadingHistory(value);
+              },
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+              shape: const RoundedRectangleBorder(
+                borderRadius: S1Shape.small,
+              ),
+            ),
+            SwitchListTile(
+              secondary: Icon(
+                Icons.vibration_outlined,
+                color: scheme.onSurfaceVariant,
+              ),
+              title: const Text('交互震动'),
+              subtitle: Text(
+                '按钮、列表与确认等操作提供触感反馈。关闭开关时仍会震动一次。仅移动端有体感。',
+                style: subtitleStyle,
+              ),
+              value: hapticsEnabled,
+              onChanged: (value) {
+                if (value) {
+                  notifier.setHapticsEnabled(true);
+                  S1Haptics.selection();
+                } else {
+                  S1Haptics.selection();
+                  notifier.setHapticsEnabled(false);
+                }
+              },
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               shape: const RoundedRectangleBorder(
                 borderRadius: S1Shape.small,

--- a/lib/widgets/settings/download_cache_settings_section.dart
+++ b/lib/widgets/settings/download_cache_settings_section.dart
@@ -9,6 +9,7 @@ import '../../models/image_load_policy.dart';
 import '../../providers/image_cache_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 import '../../utils/s1_snack_bar.dart';
 import '../s1_confirm_dialog.dart';
 import 'settings_section_header.dart';
@@ -148,6 +149,7 @@ class _DownloadCacheSettingsSectionState
                     selected: {settings.imageCacheLimitMb},
                     showSelectedIcon: false,
                     onSelectionChanged: (selection) {
+                      S1Haptics.selection();
                       notifier.setImageCacheLimitMb(selection.first);
                     },
                   ),
@@ -166,7 +168,10 @@ class _DownloadCacheSettingsSectionState
                 ),
               ),
               value: settings.showImages,
-              onChanged: notifier.setShowImages,
+              onChanged: (value) {
+                S1Haptics.selection();
+                notifier.setShowImages(value);
+              },
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               shape: const RoundedRectangleBorder(
                 borderRadius: S1Shape.small,
@@ -209,6 +214,7 @@ class _DownloadCacheSettingsSectionState
                         selected: {settings.imageLoadPolicy},
                         showSelectedIcon: false,
                         onSelectionChanged: (selection) {
+                          S1Haptics.selection();
                           notifier.setImageLoadPolicy(selection.first);
                         },
                       ),
@@ -250,6 +256,7 @@ class _DownloadCacheSettingsSectionState
                     selected: {settings.avatarLoadPolicy},
                     showSelectedIcon: false,
                     onSelectionChanged: (selection) {
+                      S1Haptics.selection();
                       notifier.setAvatarLoadPolicy(selection.first);
                     },
                   ),
@@ -284,6 +291,7 @@ class _DownloadCacheSettingsSectionState
                     // 避免默认勾号挤压两位数标签并触发换行。
                     showSelectedIcon: false,
                     onSelectionChanged: (selection) {
+                      S1Haptics.selection();
                       notifier.setMaxImagesPerPost(selection.first);
                     },
                   ),

--- a/lib/widgets/settings/font_size_section.dart
+++ b/lib/widgets/settings/font_size_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/settings_provider.dart';
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 import 'settings_section_header.dart';
 
 class FontSizeSection extends ConsumerWidget {
@@ -41,7 +42,10 @@ class FontSizeSection extends ConsumerWidget {
                     )
                     .toList(),
                 selected: {fontSize},
-                onSelectionChanged: (v) => notifier.setFontSize(v.first),
+                onSelectionChanged: (v) {
+                  S1Haptics.selection();
+                  notifier.setFontSize(v.first);
+                },
                 showSelectedIcon: false,
               ),
             ),

--- a/lib/widgets/settings/post_signature_settings_section.dart
+++ b/lib/widgets/settings/post_signature_settings_section.dart
@@ -5,6 +5,7 @@ import '../../config/constants.dart';
 import '../../providers/device_model_label_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 import '../../utils/post_signature.dart';
 import 'settings_section_header.dart';
 
@@ -74,7 +75,10 @@ class _PostSignatureSettingsSectionState
                   ),
                 ),
                 value: settings.postSignatureEnabled,
-                onChanged: notifier.setPostSignatureEnabled,
+                onChanged: (value) {
+                  S1Haptics.selection();
+                  notifier.setPostSignatureEnabled(value);
+                },
                 contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                 shape: const RoundedRectangleBorder(
                   borderRadius: S1Shape.small,
@@ -94,7 +98,10 @@ class _PostSignatureSettingsSectionState
                 ),
                 value: settings.postSignatureShowDevice,
                 onChanged: settings.postSignatureEnabled
-                    ? notifier.setPostSignatureShowDevice
+                    ? (value) {
+                        S1Haptics.selection();
+                        notifier.setPostSignatureShowDevice(value);
+                      }
                     : null,
                 contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                 shape: const RoundedRectangleBorder(

--- a/lib/widgets/settings/share_settings_section.dart
+++ b/lib/widgets/settings/share_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/share_image_format.dart';
 import '../../models/share_pixel_ratio.dart';
 import '../../providers/settings_provider.dart';
+import '../../theme/s1_haptics.dart';
 import 'settings_section_header.dart';
 
 class ShareSettingsSection extends ConsumerWidget {
@@ -59,6 +60,7 @@ class ShareSettingsSection extends ConsumerWidget {
                       selected: {settings.shareImageFormat},
                       showSelectedIcon: false,
                       onSelectionChanged: (selection) {
+                        S1Haptics.selection();
                         notifier.setShareImageFormat(selection.first);
                       },
                     ),
@@ -98,6 +100,7 @@ class ShareSettingsSection extends ConsumerWidget {
                       selected: {settings.sharePixelRatio},
                       showSelectedIcon: false,
                       onSelectionChanged: (selection) {
+                        S1Haptics.selection();
                         notifier.setSharePixelRatio(selection.first);
                       },
                     ),

--- a/lib/widgets/settings/theme_color_picker.dart
+++ b/lib/widgets/settings/theme_color_picker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 
 const _colorLabels = {
   'blue': '冷蓝',
@@ -48,7 +49,12 @@ class ThemeColorPicker extends StatelessWidget {
           child: Tooltip(
             message: _colorLabels[key] ?? key,
             child: InkWell(
-              onTap: onChanged != null ? () => onChanged!(key) : null,
+              onTap: onChanged != null
+                  ? () {
+                      S1Haptics.selection();
+                      onChanged!(key);
+                    }
+                  : null,
               borderRadius: S1Shape.full,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),

--- a/lib/widgets/settings/theme_settings_section.dart
+++ b/lib/widgets/settings/theme_settings_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/settings_provider.dart';
 import '../../theme/app_theme.dart';
+import '../../theme/s1_haptics.dart';
 import '../../utils/compact_label.dart';
 import 'settings_section_header.dart';
 import 'theme_color_picker.dart';
@@ -92,7 +93,10 @@ class ThemeModeSelector extends StatelessWidget {
       child: SegmentedButton<String>(
         segments: segments,
         selected: {themeMode},
-        onSelectionChanged: (v) => onChanged(v.first),
+        onSelectionChanged: (v) {
+          S1Haptics.selection();
+          onChanged(v.first);
+        },
         showSelectedIcon: false,
         style: S1SegmentedButtonStyle.forScheme(scheme).merge(
           ButtonStyle(

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -5,6 +5,7 @@ import '../config/constants.dart';
 import '../models/thread.dart';
 import '../providers/reading_history_provider.dart';
 import '../theme/app_theme.dart';
+import '../theme/s1_haptics.dart';
 import '../models/thread_destination.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
@@ -39,6 +40,7 @@ class ThreadCard extends ConsumerWidget {
 
   /// 点击：按阅读记录解析目标页（续读 / 已读落末页 / 有新回复落新页）。
   void _handleTap(BuildContext context, WidgetRef ref) {
+    S1Haptics.selection();
     if (onOpenThread != null) {
       final record = ref.read(readingRecordProvider(thread.tid));
       final targetPage = record?.resolveOpenPage(thread.replies);

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:s1er/models/share_image_format.dart';
 import 'package:s1er/providers/settings_provider.dart';
 import 'package:s1er/services/settings_store.dart';
 import 'package:s1er/theme/app_theme.dart';
+import 'package:s1er/theme/s1_haptics.dart';
 import '../helpers/test_local_data.dart';
 
 void main() {
@@ -75,6 +76,28 @@ void main() {
     expect(container.read(settingsProvider).recordReadingHistory, isFalse);
     await Future<void>.delayed(const Duration(milliseconds: 50));
     expect(store.get<bool>('recordReadingHistory'), isFalse);
+  });
+
+  test('setHapticsEnabled persists and syncs S1Haptics.enabled', () async {
+    S1Haptics.enabled = true;
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(store: store, initial: const AppSettings()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(settingsProvider.notifier).setHapticsEnabled(false);
+
+    expect(container.read(settingsProvider).hapticsEnabled, isFalse);
+    expect(S1Haptics.enabled, isFalse);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(store.get<bool>('hapticsEnabled'), isFalse);
+
+    container.read(settingsProvider.notifier).setHapticsEnabled(true);
+    expect(S1Haptics.enabled, isTrue);
   });
 
   test('legacy custom theme colors are normalized to the default preset', () {

--- a/test/services/s1_backup_service_test.dart
+++ b/test/services/s1_backup_service_test.dart
@@ -124,6 +124,16 @@ void main() {
       expect(app['postSignatureShowDevice'], isFalse);
       expect(app['postSignatureCustom'], '摸鱼');
     });
+
+    test('haptics_enabled maps to camelCase', () {
+      final backup = S1BackupSettingsMapper.toBackup({
+        'hapticsEnabled': false,
+      });
+      expect(backup['haptics_enabled'], isFalse);
+
+      final app = S1BackupSettingsMapper.toApp(backup);
+      expect(app['hapticsEnabled'], isFalse);
+    });
   });
 
   group('S1BackupService L1 round-trip', () {

--- a/test/theme/s1_haptics_test.dart
+++ b/test/theme/s1_haptics_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1er/theme/s1_haptics.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    S1Haptics.enabled = true;
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      calls.add(call);
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    S1Haptics.enabled = true;
+  });
+
+  test('selection / light / medium / heavy map to platform args', () async {
+    S1Haptics.selection();
+    S1Haptics.light();
+    S1Haptics.medium();
+    S1Haptics.heavy();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      calls.map((c) => '${c.method}:${c.arguments}').toList(),
+      [
+        'HapticFeedback.vibrate:HapticFeedbackType.selectionClick',
+        'HapticFeedback.vibrate:HapticFeedbackType.lightImpact',
+        'HapticFeedback.vibrate:HapticFeedbackType.mediumImpact',
+        'HapticFeedback.vibrate:HapticFeedbackType.heavyImpact',
+      ],
+    );
+  });
+
+  test('disabled gate suppresses platform calls', () async {
+    S1Haptics.enabled = false;
+    S1Haptics.selection();
+    S1Haptics.light();
+    S1Haptics.medium();
+    S1Haptics.heavy();
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, isEmpty);
+  });
+
+  test('wrapTap fires selection before callback', () async {
+    var ran = false;
+    final wrapped = S1Haptics.wrapTap(() => ran = true);
+    wrapped!();
+    await Future<void>.delayed(Duration.zero);
+    expect(ran, isTrue);
+    expect(calls.single.arguments, 'HapticFeedbackType.selectionClick');
+  });
+
+  test('wrapLongPress fires medium before callback', () async {
+    var ran = false;
+    final wrapped = S1Haptics.wrapLongPress(() => ran = true);
+    wrapped!();
+    await Future<void>.delayed(Duration.zero);
+    expect(ran, isTrue);
+    expect(calls.single.arguments, 'HapticFeedbackType.mediumImpact');
+  });
+
+  test('wrapTap / wrapLongPress return null for null callbacks', () {
+    expect(S1Haptics.wrapTap(null), isNull);
+    expect(S1Haptics.wrapLongPress(null), isNull);
+  });
+
+  test('wrapRefresh fires light then runs refresh', () async {
+    var ran = false;
+    await S1Haptics.wrapRefresh(() async {
+      ran = true;
+    });
+    await Future<void>.delayed(Duration.zero);
+    expect(ran, isTrue);
+    expect(calls.single.arguments, 'HapticFeedbackType.lightImpact');
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 S1er 落地完整交互震动：语义化 `S1Haptics` token、设置总开关（默认开）、备份字段，并在主要手势路径尽量全覆盖。

### 架构
- [`lib/theme/s1_haptics.dart`](lib/theme/s1_haptics.dart)：`selection` / `light` / `medium` / `heavy` + `wrapTap` / `wrapLongPress` / `wrapRefresh`
- `S1Haptics.enabled` 由 [`SettingsNotifier`](lib/providers/settings_provider.dart) 同步；业务代码不再直接调用 `HapticFeedback.*`
- 浏览设置新增「交互震动」开关；备份 key `haptics_enabled`

### 覆盖
- 原语：`S1ClickRegion`、列表砖、`ThreadCard`、导航栏 / Rail、分页 / 滑动翻页、设置 Switch / Segmented / 主题色
- 写操作：收藏、评分、投票、发帖/回复、签到、分享导出、确认弹窗
- 刷新：`RefreshIndicator` 与 AppBar 刷新菜单
- 错误：`S1SnackBar.error` / 登录失败 `heavy`

### 验证
- `flutter analyze`：无 issue
- `flutter test`：831 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f74df-9330-7051-9249-4a72048c32d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f74df-9330-7051-9249-4a72048c32d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

