### PR TITLE
fix(thread): record last floor when scrolled to page bottom

### DIFF
--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -69,6 +69,19 @@ bool shouldWriteReadingProgressUpdate({
   return lastRecordedFloorInPage != currentFloorInPage;
 }
 
+/// 阅读进度写回用的页内楼层（1-based）。
+///
+/// 平常取视口锚线上方最后一楼；已滚到页底时取本页末楼，避免短帖读完后仍停在较早楼层。
+int resolveFloorInPageForProgress({
+  required int leadingIndex,
+  required int postCount,
+  required bool atPageBottom,
+}) {
+  if (postCount <= 0) return 1;
+  if (atPageBottom) return postCount;
+  return leadingIndex.clamp(0, postCount - 1) + 1;
+}
+
 /// 滚动 FAB 显隐状态（用 [ValueNotifier] 更新，避免重建列表）。
 class _ScrollFabVisibility {
   const _ScrollFabVisibility({
@@ -188,12 +201,24 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
             const Duration(milliseconds: 400)) {
       return;
     }
-    final index = ScrollFloorNavigator.findLeadingVisiblePostIndex(
+    final floorInPage = _resolveVisibleFloorInPage(state);
+    if (floorInPage == null) return;
+    _lastFloorProgressAt = now;
+    _recordProgress(state, floorInPage: floorInPage);
+  }
+
+  int? _resolveVisibleFloorInPage(PostListState state) {
+    if (state.posts.isEmpty) return null;
+    final leading = ScrollFloorNavigator.findLeadingVisiblePostIndex(
       postKeys: _postKeys,
     );
-    if (index == null) return;
-    _lastFloorProgressAt = now;
-    _recordProgress(state, floorInPage: index + 1);
+    final atBottom = _scrollFabVisibility.value.atPageBottom;
+    if (leading == null && !atBottom) return null;
+    return resolveFloorInPageForProgress(
+      leadingIndex: leading ?? 0,
+      postCount: state.posts.length,
+      atPageBottom: atBottom,
+    );
   }
 
   Future<void> _consumeOpenScrollTarget(PostListState state) async {

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -35,6 +35,7 @@ import '../widgets/s1_swipe_pagination.dart';
 import '../widgets/scroll_pointer_gate.dart';
 import '../widgets/s1_desktop_scaffold.dart';
 import '../widgets/s1_content_width.dart';
+import '../models/reading_record.dart';
 import '../models/open_scroll_target.dart';
 import '../models/thread_destination.dart';
 import '../models/thread_open_intent.dart';
@@ -72,14 +73,18 @@ bool shouldWriteReadingProgressUpdate({
 /// 阅读进度写回用的页内楼层（1-based）。
 ///
 /// 平常取视口锚线上方最后一楼；已滚到页底时取本页末楼，避免短帖读完后仍停在较早楼层。
+/// [minFloorInPage] 用于同页内单调递增，防止从页底回滑时进度回退。
 int resolveFloorInPageForProgress({
   required int leadingIndex,
   required int postCount,
   required bool atPageBottom,
+  int minFloorInPage = 1,
 }) {
   if (postCount <= 0) return 1;
-  if (atPageBottom) return postCount;
-  return leadingIndex.clamp(0, postCount - 1) + 1;
+  final raw = atPageBottom
+      ? postCount
+      : leadingIndex.clamp(0, postCount - 1) + 1;
+  return raw < minFloorInPage ? minFloorInPage : raw;
 }
 
 /// 滚动 FAB 显隐状态（用 [ValueNotifier] 更新，避免重建列表）。
@@ -162,7 +167,29 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     }
     // Prefer the caller-provided / last visible floor. Never fall back to
     // `posts.length` (that permanently wrote "page end" as fake progress).
-    final resolvedFloor = floorInPage ?? _lastRecordedFloorInPage ?? 1;
+    var resolvedFloor = floorInPage ?? _lastRecordedFloorInPage ?? 1;
+    final ppp =
+        state.perPage > 0 ? state.perPage : S1Constants.postsPerPageFallback;
+    var absoluteFloor = (state.currentPage - 1) * ppp + resolvedFloor;
+
+    final persisted =
+        ref.read(readingHistoryServiceProvider).getRecord(widget.tid);
+    if (persisted != null) {
+      absoluteFloor = absoluteFloor > persisted.lastReadFloor
+          ? absoluteFloor
+          : persisted.lastReadFloor;
+    }
+    if (_lastRecordedPage == state.currentPage &&
+        _lastRecordedFloorInPage != null) {
+      final sessionAbsolute =
+          (state.currentPage - 1) * ppp + _lastRecordedFloorInPage!;
+      if (sessionAbsolute > absoluteFloor) {
+        absoluteFloor = sessionAbsolute;
+      }
+    }
+
+    resolvedFloor = (absoluteFloor - (state.currentPage - 1) * ppp)
+        .clamp(1, state.posts.isEmpty ? 1 : state.posts.length);
     if (!shouldWriteReadingProgressUpdate(
       hasRecordedInitialVisit: _hasRecordedInitialVisit,
       lastRecordedPage: _lastRecordedPage,
@@ -194,17 +221,29 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     }
   }
 
-  void _maybeRecordVisibleFloor(PostListState state) {
-    final now = DateTime.now();
-    if (_lastFloorProgressAt != null &&
-        now.difference(_lastFloorProgressAt!) <
-            const Duration(milliseconds: 400)) {
-      return;
+  void _maybeRecordVisibleFloor(PostListState state, {bool force = false}) {
+    final atBottom = _scrollFabVisibility.value.atPageBottom;
+    if (!force && !atBottom) {
+      final now = DateTime.now();
+      if (_lastFloorProgressAt != null &&
+          now.difference(_lastFloorProgressAt!) <
+              const Duration(milliseconds: 400)) {
+        return;
+      }
+      _lastFloorProgressAt = now;
     }
     final floorInPage = _resolveVisibleFloorInPage(state);
     if (floorInPage == null) return;
-    _lastFloorProgressAt = now;
+    if (!force) {
+      _lastFloorProgressAt = DateTime.now();
+    }
     _recordProgress(state, floorInPage: floorInPage);
+  }
+
+  void _flushProgressBeforeLeave() {
+    final state = ref.read(postProvider(widget.tid)).asData?.value;
+    if (state == null) return;
+    _maybeRecordVisibleFloor(state, force: true);
   }
 
   int? _resolveVisibleFloorInPage(PostListState state) {
@@ -214,10 +253,33 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     );
     final atBottom = _scrollFabVisibility.value.atPageBottom;
     if (leading == null && !atBottom) return null;
+
+    var minFloor = 1;
+    if (_lastRecordedPage == state.currentPage &&
+        _lastRecordedFloorInPage != null) {
+      minFloor = _lastRecordedFloorInPage!;
+    }
+    final persisted =
+        ref.read(readingHistoryServiceProvider).getRecord(widget.tid);
+    if (persisted != null) {
+      final ppp =
+          state.perPage > 0 ? state.perPage : S1Constants.postsPerPageFallback;
+      final persistedPage =
+          pageForFloor(persisted.lastReadFloor, perPage: ppp);
+      if (persistedPage == state.currentPage) {
+        final persistedInPage =
+            persisted.lastReadFloor - (state.currentPage - 1) * ppp;
+        if (persistedInPage > minFloor) {
+          minFloor = persistedInPage;
+        }
+      }
+    }
+
     return resolveFloorInPageForProgress(
       leadingIndex: leading ?? 0,
       postCount: state.posts.length,
       atPageBottom: atBottom,
+      minFloorInPage: minFloor,
     );
   }
 
@@ -708,6 +770,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
       await _restoreInThreadJump();
       return true;
     }
+    _flushProgressBeforeLeave();
     return false;
   }
 
@@ -775,10 +838,12 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
                         return;
                       }
                       if (widget.onClose != null) {
+                        _flushProgressBeforeLeave();
                         widget.onClose!();
                         return;
                       }
                       if (context.canPop()) {
+                        _flushProgressBeforeLeave();
                         context.pop();
                       }
                     },

--- a/test/screens/thread_detail_nav_integration_test.dart
+++ b/test/screens/thread_detail_nav_integration_test.dart
@@ -254,6 +254,46 @@ void main() {
     expect(after.lastReadPage, 1);
   });
 
+  testWidgets('short single-page thread records last floor at page bottom',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    adapter.postsPerPage = 5;
+    adapter.totalReplies = 4;
+
+    await pumpThread(
+      tester: tester,
+      location: '/thread/100',
+    );
+
+    expect(find.textContaining('MARK-FLOOR-1'), findsOneWidget);
+
+    final listFinder = find.descendant(
+      of: find.byType(ThreadDetailScreen),
+      matching: find.byType(ListView),
+    );
+    final controller = tester.widget<ListView>(listFinder).controller!;
+    expect(controller.position.maxScrollExtent, greaterThan(0));
+
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 450)),
+    );
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await _pumpFrames(tester, 15);
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 450)),
+    );
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await _pumpFrames(tester, 15);
+
+    final record =
+        rootContainer!.read(readingHistoryServiceProvider).getRecord('100')!;
+    expect(record.lastReadFloor, 5);
+    expect(record.lastReadPage, 1);
+  });
+
   testWidgets('forced page=1 ignores resume floor and stays at page top',
       (tester) async {
     tester.view.physicalSize = const Size(800, 1200);

--- a/test/screens/thread_detail_progress_dedup_test.dart
+++ b/test/screens/thread_detail_progress_dedup_test.dart
@@ -53,4 +53,50 @@ void main() {
       isTrue,
     );
   });
+
+  group('resolveFloorInPageForProgress', () {
+    test('uses leading floor while not at page bottom', () {
+      expect(
+        resolveFloorInPageForProgress(
+          leadingIndex: 2,
+          postCount: 5,
+          atPageBottom: false,
+        ),
+        3,
+      );
+    });
+
+    test('uses last floor when scrolled to page bottom', () {
+      expect(
+        resolveFloorInPageForProgress(
+          leadingIndex: 2,
+          postCount: 5,
+          atPageBottom: true,
+        ),
+        5,
+      );
+    });
+
+    test('clamps leading index to post count', () {
+      expect(
+        resolveFloorInPageForProgress(
+          leadingIndex: 99,
+          postCount: 5,
+          atPageBottom: false,
+        ),
+        5,
+      );
+    });
+
+    test('empty page falls back to floor 1', () {
+      expect(
+        resolveFloorInPageForProgress(
+          leadingIndex: 0,
+          postCount: 0,
+          atPageBottom: true,
+        ),
+        1,
+      );
+    });
+  });
 }

--- a/test/screens/thread_detail_progress_dedup_test.dart
+++ b/test/screens/thread_detail_progress_dedup_test.dart
@@ -98,5 +98,17 @@ void main() {
         1,
       );
     });
+
+    test('does not regress below minFloorInPage', () {
+      expect(
+        resolveFloorInPageForProgress(
+          leadingIndex: 1,
+          postCount: 5,
+          atPageBottom: false,
+          minFloorInPage: 5,
+        ),
+        5,
+      );
+    });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On short single-page threads (e.g. 5 floors total), scrolling to the bottom and returning to the list showed reading progress stuck at an earlier floor (e.g. `#3`) instead of the last floor.

## Root cause

Reading progress writeback used only the **leading visible floor** — the last post whose top is above the 8% viewport anchor (`ScrollFloorNavigator.revealAlignment`). When the user scrolls to the page bottom, later floors (#4, #5) can remain fully visible but **below** that anchor, so progress never advanced past #3.

## Fix

- Introduce `resolveFloorInPageForProgress()`:
  - While not at page bottom → keep leading-visible floor behavior (avoids fake "read entire page" on open).
  - When at page bottom → record the last post on the current page.
- **Follow-up hardening (review)**:
  - Clamp with session + persisted min floor so scrolling back up from page bottom does not regress `lastReadFloor`.
  - Skip 400ms throttle while at page bottom.
  - Flush progress before explicit back / embedded close actions.

## Tests

- Unit tests for `resolveFloorInPageForProgress` (including non-regression) in `thread_detail_progress_dedup_test.dart`.
- Integration scenario for a 5-floor single-page thread in `thread_detail_nav_integration_test.dart`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e81507-243e-4c64-bd6a-144f685db0f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e81507-243e-4c64-bd6a-144f685db0f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

