### PR TITLE
feat(ui): 窄屏列表铺满改为可选设置

### DIFF
--- a/docs/backup-format-v1.md
+++ b/docs/backup-format-v1.md
@@ -100,6 +100,7 @@ v1 **不使用** JSONL；列表一律为 JSON 数组。
 | `haptics_enabled` | bool | 交互震动总开关（默认 `true`；无触感硬件的平台可忽略） |
 | `thread_list_density` | string | `standard` / `compact`；版块主题列表密度（默认 `standard`） |
 | `post_list_density` | string | `standard` / `compact`；帖子详情楼层卡片外壳密度（默认 `standard`） |
+| `compact_list_full_bleed` | bool | 窄屏（≤599dp）主题列表与楼层去掉左右边距和圆角（默认 `false`） |
 | `thread_list_filters_expanded` | bool | 版块主题列表筛选区是否展开（默认 `false`） |
 | `font_size` | int | |
 | `collapsed_forums` | string[] | 版块 id |

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -34,6 +34,7 @@ class AppSettings {
     this.hapticsEnabled = true,
     this.threadListDensity = ListDensity.standard,
     this.postListDensity = ListDensity.standard,
+    this.compactListFullBleed = false,
     this.threadListFiltersExpanded = false,
     this.fontSize = S1Typography.defaultBodySize,
     this.collapsedForums = const {},
@@ -66,6 +67,9 @@ class AppSettings {
   final bool hapticsEnabled;
   final ListDensity threadListDensity;
   final ListDensity postListDensity;
+
+  /// Compact windows (≤599dp): thread list / post floors go edge-to-edge.
+  final bool compactListFullBleed;
   final bool threadListFiltersExpanded;
   final int fontSize;
   final Set<String> collapsedForums;
@@ -110,6 +114,7 @@ class AppSettings {
     bool? hapticsEnabled,
     ListDensity? threadListDensity,
     ListDensity? postListDensity,
+    bool? compactListFullBleed,
     bool? threadListFiltersExpanded,
     int? fontSize,
     Set<String>? collapsedForums,
@@ -142,6 +147,7 @@ class AppSettings {
       hapticsEnabled: hapticsEnabled ?? this.hapticsEnabled,
       threadListDensity: threadListDensity ?? this.threadListDensity,
       postListDensity: postListDensity ?? this.postListDensity,
+      compactListFullBleed: compactListFullBleed ?? this.compactListFullBleed,
       threadListFiltersExpanded:
           threadListFiltersExpanded ?? this.threadListFiltersExpanded,
       fontSize: fontSize ?? this.fontSize,
@@ -187,6 +193,7 @@ class AppSettings {
         other.hapticsEnabled == hapticsEnabled &&
         other.threadListDensity == threadListDensity &&
         other.postListDensity == postListDensity &&
+        other.compactListFullBleed == compactListFullBleed &&
         other.threadListFiltersExpanded == threadListFiltersExpanded &&
         other.fontSize == fontSize &&
         _setEquals(other.collapsedForums, collapsedForums) &&
@@ -234,6 +241,7 @@ class AppSettings {
         shareImageFormat,
         sharePixelRatio,
         Object.hash(
+          compactListFullBleed,
           threadListFiltersExpanded,
           shareAdvancedExport,
           shareSaveMode,
@@ -400,6 +408,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
       postListDensity: ListDensity.fromStored(
         settingsStore.get<String>('postListDensity'),
       ),
+      compactListFullBleed: settingsStore.get<bool>(
+            'compactListFullBleed',
+            defaultValue: false,
+          ) ??
+          false,
       threadListFiltersExpanded: settingsStore.get<bool>(
             'threadListFiltersExpanded',
             defaultValue: false,
@@ -606,6 +619,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
     _persist('postListDensity', value.storageKey);
   }
 
+  void setCompactListFullBleed(bool value) {
+    _commit(state.copyWith(compactListFullBleed: value));
+    _persist('compactListFullBleed', value);
+  }
+
   void setForumSplitListPaneWidth(double? value) {
     _commit(state.copyWith(forumSplitListPaneWidth: value));
     _persist('forumSplitListPaneWidth', value);
@@ -731,6 +749,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       hapticsEnabled: defaults.hapticsEnabled,
       threadListDensity: defaults.threadListDensity,
       postListDensity: defaults.postListDensity,
+      compactListFullBleed: defaults.compactListFullBleed,
       threadListFiltersExpanded: defaults.threadListFiltersExpanded,
       fontSize: defaults.fontSize,
       shareImageFormat: defaults.shareImageFormat,
@@ -758,6 +777,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
     _persist('hapticsEnabled', defaults.hapticsEnabled);
     _persist('threadListDensity', defaults.threadListDensity.storageKey);
     _persist('postListDensity', defaults.postListDensity.storageKey);
+    _persist('compactListFullBleed', defaults.compactListFullBleed);
     _persist('threadListFiltersExpanded', defaults.threadListFiltersExpanded);
     _persist('fontSize', defaults.fontSize);
     _persist('shareImageFormat', defaults.shareImageFormat.storageKey);

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -59,6 +59,7 @@ import '../models/share_floor_data.dart';
 import '../utils/share_floor_selection.dart';
 import '../theme/app_theme.dart';
 import '../theme/s1_haptics.dart';
+import '../theme/s1_reading_card_style.dart';
 
 bool shouldRecordReadingProgress(AppSettings settings, AuthState auth) {
   if (!settings.recordReadingHistory) {
@@ -1683,18 +1684,28 @@ class _BlockedPostPlaceholder extends ConsumerWidget {
     final tokens = PostItemDensityTokens.forDensity(
       ref.watch(settingsProvider.select((s) => s.postListDensity)),
     );
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
 
     return Card(
-      margin: EdgeInsets.symmetric(
-        horizontal: 8,
+      margin: S1ReadingCardStyle.margin(
+        context,
+        enabled: compactListFullBleed,
         vertical: tokens.cardMarginVertical,
       ),
       elevation: 0,
       color: S1Surface.card(scheme),
-      shape: S1Shape.cardShape,
+      shape: S1ReadingCardStyle.shape(
+        context,
+        enabled: compactListFullBleed,
+      ),
       child: InkWell(
         onTap: onExpand,
-        borderRadius: S1Shape.medium,
+        borderRadius: S1ReadingCardStyle.inkBorderRadius(
+          context,
+          enabled: compactListFullBleed,
+        ),
         child: Padding(
           padding: EdgeInsets.symmetric(
             horizontal: tokens.cardPadding,

--- a/lib/services/backup/s1_backup_codec.dart
+++ b/lib/services/backup/s1_backup_codec.dart
@@ -203,6 +203,7 @@ class S1BackupSettingsMapper {
     'hapticsEnabled': 'haptics_enabled',
     'threadListDensity': 'thread_list_density',
     'postListDensity': 'post_list_density',
+    'compactListFullBleed': 'compact_list_full_bleed',
     'threadListFiltersExpanded': 'thread_list_filters_expanded',
     'forumSplitListPaneWidth': 'forum_split_list_pane_width',
     'fontSize': 'font_size',

--- a/lib/services/backup/s1_backup_service.dart
+++ b/lib/services/backup/s1_backup_service.dart
@@ -67,6 +67,7 @@ class S1BackupService {
     appSettings.putIfAbsent('hapticsEnabled', () => true);
     appSettings.putIfAbsent('threadListDensity', () => 'standard');
     appSettings.putIfAbsent('postListDensity', () => 'standard');
+    appSettings.putIfAbsent('compactListFullBleed', () => false);
     appSettings.putIfAbsent('threadListFiltersExpanded', () => true);
     appSettings.putIfAbsent('fontSize', () => 14);
     appSettings.putIfAbsent('collapsedForums', () => <String>[]);

--- a/lib/theme/s1_reading_card_style.dart
+++ b/lib/theme/s1_reading_card_style.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../utils/window_size.dart';
+import 'app_theme.dart';
+
+/// Geometry for thread-list / post-floor cards.
+///
+/// When [enabled] and the window is compact (≤599dp), cards go full-bleed:
+/// no side gutter and no corner radius. Wider windows keep the floating card.
+abstract final class S1ReadingCardStyle {
+  static const double sideMargin = 8;
+
+  static bool isFullBleed(BuildContext context, {required bool enabled}) {
+    return enabled && context.windowSize == S1WindowSize.compact;
+  }
+
+  static EdgeInsets margin(
+    BuildContext context, {
+    required bool enabled,
+    required double vertical,
+  }) {
+    return EdgeInsets.symmetric(
+      horizontal: isFullBleed(context, enabled: enabled) ? 0 : sideMargin,
+      vertical: vertical,
+    );
+  }
+
+  static BorderRadius inkBorderRadius(
+    BuildContext context, {
+    required bool enabled,
+  }) {
+    return isFullBleed(context, enabled: enabled)
+        ? BorderRadius.zero
+        : S1Shape.medium;
+  }
+
+  static ShapeBorder shape(
+    BuildContext context, {
+    required bool enabled,
+    BorderSide side = BorderSide.none,
+  }) {
+    return RoundedRectangleBorder(
+      borderRadius: inkBorderRadius(context, enabled: enabled),
+      side: side,
+    );
+  }
+}

--- a/lib/widgets/poll_card.dart
+++ b/lib/widgets/poll_card.dart
@@ -5,8 +5,10 @@ import '../models/poll.dart';
 import '../providers/auth_provider.dart';
 import '../providers/poll_vote_provider.dart';
 import '../providers/post_provider.dart';
+import '../providers/settings_provider.dart';
 import '../theme/app_theme.dart';
 import '../theme/s1_haptics.dart';
+import '../theme/s1_reading_card_style.dart';
 import '../utils/format_utils.dart';
 import '../utils/poll_bar_color.dart';
 import '../utils/s1_snack_bar.dart';
@@ -112,12 +114,22 @@ class _PollCardState extends ConsumerState<PollCard> {
     );
     final showResults = poll.showResults;
     final canInteract = poll.canVote && isLoggedIn;
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
 
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      margin: S1ReadingCardStyle.margin(
+        context,
+        enabled: compactListFullBleed,
+        vertical: 4,
+      ),
       elevation: 0,
       color: S1Surface.card(scheme),
-      shape: S1Shape.cardShape,
+      shape: S1ReadingCardStyle.shape(
+        context,
+        enabled: compactListFullBleed,
+      ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(12, 12, 12, 16),
         child: Column(

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -10,6 +10,7 @@ import '../providers/thread_rate_logs_provider.dart';
 import '../providers/user_profile_provider.dart';
 import '../theme/app_theme.dart';
 import '../theme/s1_haptics.dart';
+import '../theme/s1_reading_card_style.dart';
 import '../utils/banned_post_detector.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
@@ -233,6 +234,9 @@ class _PostItemState extends ConsumerState<PostItem>
     final tokens = PostItemDensityTokens.forDensity(
       ref.watch(settingsProvider.select((s) => s.postListDensity)),
     );
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
     final globalStrip = ref.watch(
       settingsProvider.select((s) => s.stripSpecialStyles),
     );
@@ -245,8 +249,9 @@ class _PostItemState extends ConsumerState<PostItem>
 
     final selected = widget.shareSelectMode && widget.isShareSelected;
     final card = Card(
-      margin: EdgeInsets.symmetric(
-        horizontal: 8,
+      margin: S1ReadingCardStyle.margin(
+        context,
+        enabled: compactListFullBleed,
         vertical: tokens.cardMarginVertical,
       ),
       elevation: 0,
@@ -255,12 +260,13 @@ class _PostItemState extends ConsumerState<PostItem>
           : widget.isHighlighted
               ? scheme.primaryContainer.withValues(alpha: S1Alpha.half)
               : S1Surface.card(scheme),
-      shape: selected
-          ? RoundedRectangleBorder(
-              borderRadius: S1Shape.medium,
-              side: BorderSide(color: scheme.secondary, width: 1.5),
-            )
-          : S1Shape.cardShape,
+      shape: S1ReadingCardStyle.shape(
+        context,
+        enabled: compactListFullBleed,
+        side: selected
+            ? BorderSide(color: scheme.secondary, width: 1.5)
+            : BorderSide.none,
+      ),
       child: Padding(
         padding: tokens.contentPadding,
         child: Column(

--- a/lib/widgets/settings/browsing_settings_section.dart
+++ b/lib/widgets/settings/browsing_settings_section.dart
@@ -25,6 +25,9 @@ class BrowsingSettingsSection extends ConsumerWidget {
     final postListDensity = ref.watch(
       settingsProvider.select((settings) => settings.postListDensity),
     );
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((settings) => settings.compactListFullBleed),
+    );
     final stripSpecialStyles = ref.watch(
       settingsProvider.select((settings) => settings.stripSpecialStyles),
     );
@@ -150,6 +153,27 @@ class BrowsingSettingsSection extends ConsumerWidget {
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               shape: const RoundedRectangleBorder(borderRadius: S1Shape.small),
               onTap: () => context.push('/hidden-forums'),
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              secondary: Icon(
+                Icons.view_agenda_outlined,
+                color: scheme.onSurfaceVariant,
+              ),
+              title: const Text('窄屏列表铺满'),
+              subtitle: Text(
+                '仅竖屏手机去掉主题列表和楼层卡片的左右边距与圆角。平板和桌面不受影响。',
+                style: subtitleStyle,
+              ),
+              value: compactListFullBleed,
+              onChanged: (value) {
+                S1Haptics.selection();
+                notifier.setCompactListFullBleed(value);
+              },
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+              shape: const RoundedRectangleBorder(
+                borderRadius: S1Shape.small,
+              ),
             ),
             const SizedBox(height: 8),
             Padding(

--- a/lib/widgets/settings/browsing_settings_section.dart
+++ b/lib/widgets/settings/browsing_settings_section.dart
@@ -155,32 +155,32 @@ class BrowsingSettingsSection extends ConsumerWidget {
               onTap: () => context.push('/hidden-forums'),
             ),
             const SizedBox(height: 8),
-            SwitchListTile(
-              secondary: Icon(
-                Icons.view_agenda_outlined,
-                color: scheme.onSurfaceVariant,
-              ),
-              title: const Text('窄屏列表铺满'),
-              subtitle: Text(
-                '仅竖屏手机去掉主题列表和楼层卡片的左右边距与圆角。平板和桌面不受影响。',
-                style: subtitleStyle,
-              ),
-              value: compactListFullBleed,
-              onChanged: (value) {
-                S1Haptics.selection();
-                notifier.setCompactListFullBleed(value);
-              },
-              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-              shape: const RoundedRectangleBorder(
-                borderRadius: S1Shape.small,
-              ),
-            ),
-            const SizedBox(height: 8),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  SwitchListTile(
+                    secondary: Icon(
+                      Icons.view_agenda_outlined,
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    title: const Text('窄屏列表铺满'),
+                    subtitle: Text(
+                      '窗口宽度不足 600 时去掉主题列表和楼层卡片的左右边距与圆角（一般是竖屏手机）。',
+                      style: subtitleStyle,
+                    ),
+                    value: compactListFullBleed,
+                    onChanged: (value) {
+                      S1Haptics.selection();
+                      notifier.setCompactListFullBleed(value);
+                    },
+                    contentPadding: EdgeInsets.zero,
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: S1Shape.small,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
                   Text('主题列表密度', style: textTheme.titleSmall),
                   const SizedBox(height: 4),
                   Text(

--- a/lib/widgets/skeleton/post_item_skeleton.dart
+++ b/lib/widgets/skeleton/post_item_skeleton.dart
@@ -1,18 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/settings_provider.dart';
 import 's1_skeleton_shapes.dart';
 import 's1_viewport_skeleton_list.dart';
 
 /// 对齐 [PostItem] 的帖子楼层骨架。
-class PostItemSkeleton extends StatelessWidget {
+class PostItemSkeleton extends ConsumerWidget {
   const PostItemSkeleton({super.key});
 
   static const estimatedHeight = 168.0;
 
   @override
-  Widget build(BuildContext context) {
-    return const S1SkeletonCard(
-      child: Column(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
+    return S1SkeletonCard(
+      compactListFullBleed: compactListFullBleed,
+      child: const Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(

--- a/lib/widgets/skeleton/s1_skeleton_shapes.dart
+++ b/lib/widgets/skeleton/s1_skeleton_shapes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../theme/app_theme.dart';
+import '../../theme/s1_reading_card_style.dart';
 
 /// M3 骨架基础形状（色取自 [ColorScheme] / [TextTheme]）。
 abstract class S1SkeletonShapes {
@@ -66,23 +67,32 @@ class S1SkeletonCard extends StatelessWidget {
   const S1SkeletonCard({
     super.key,
     required this.child,
-    this.margin = const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+    this.verticalMargin = 4,
     this.padding = const EdgeInsets.all(12),
+    this.compactListFullBleed = false,
   });
 
   final Widget child;
-  final EdgeInsetsGeometry margin;
+  final double verticalMargin;
   final EdgeInsetsGeometry padding;
+  final bool compactListFullBleed;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return Padding(
-      padding: margin,
+      padding: S1ReadingCardStyle.margin(
+        context,
+        enabled: compactListFullBleed,
+        vertical: verticalMargin,
+      ),
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: S1SkeletonShapes.cardColor(scheme),
-          borderRadius: S1Shape.medium,
+          borderRadius: S1ReadingCardStyle.inkBorderRadius(
+            context,
+            enabled: compactListFullBleed,
+          ),
         ),
         child: Padding(padding: padding, child: child),
       ),

--- a/lib/widgets/skeleton/thread_card_skeleton.dart
+++ b/lib/widgets/skeleton/thread_card_skeleton.dart
@@ -1,20 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/settings_provider.dart';
 import 's1_skeleton_shapes.dart';
 import 's1_viewport_skeleton_list.dart';
 
 /// 对齐 [ThreadCard] 的主题列表项骨架。
-class ThreadCardSkeleton extends StatelessWidget {
+class ThreadCardSkeleton extends ConsumerWidget {
   const ThreadCardSkeleton({super.key});
 
   static const estimatedHeight = 108.0;
 
   @override
-  Widget build(BuildContext context) {
-    return const S1SkeletonCard(
-      margin: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-      child: Column(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
+    return S1SkeletonCard(
+      compactListFullBleed: compactListFullBleed,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      child: const Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           S1SkeletonBar(),

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -8,6 +8,7 @@ import '../providers/reading_history_provider.dart';
 import '../providers/settings_provider.dart';
 import '../theme/app_theme.dart';
 import '../theme/s1_haptics.dart';
+import '../theme/s1_reading_card_style.dart';
 import '../models/thread_destination.dart';
 import '../utils/compact_label.dart';
 import '../utils/format_utils.dart';
@@ -200,6 +201,9 @@ class ThreadCard extends ConsumerWidget {
     final density = ref.watch(
       settingsProvider.select((s) => s.threadListDensity),
     );
+    final compactListFullBleed = ref.watch(
+      settingsProvider.select((s) => s.compactListFullBleed),
+    );
     final tokens = ThreadCardDensityTokens.forDensity(density);
     final hasTag = thread.typeName != null && thread.typeName!.isNotEmpty;
     final isSticky = thread.isSticky;
@@ -227,8 +231,9 @@ class ThreadCard extends ConsumerWidget {
       button: true,
       label: thread.subject,
       child: Card(
-        margin: EdgeInsets.symmetric(
-          horizontal: 8,
+        margin: S1ReadingCardStyle.margin(
+          context,
+          enabled: compactListFullBleed,
           vertical: tokens.cardMarginVertical,
         ),
         elevation: 0,
@@ -239,11 +244,17 @@ class ThreadCard extends ConsumerWidget {
             : isSticky
                 ? scheme.primaryContainer
                 : S1Surface.card(scheme),
-        shape: S1Shape.cardShape,
+        shape: S1ReadingCardStyle.shape(
+          context,
+          enabled: compactListFullBleed,
+        ),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           onTap: () => _handleTap(context, ref),
-          borderRadius: S1Shape.medium,
+          borderRadius: S1ReadingCardStyle.inkBorderRadius(
+            context,
+            enabled: compactListFullBleed,
+          ),
           child: Padding(
             padding: EdgeInsets.symmetric(
               horizontal: 12,

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -74,6 +74,7 @@ void main() {
     expect(state.shareAdvancedExport, isFalse);
     expect(state.threadListDensity, ListDensity.standard);
     expect(state.postListDensity, ListDensity.standard);
+    expect(state.compactListFullBleed, isFalse);
     expect(state.stripSpecialStyles, isFalse);
     expect(state.hideStickyThreads, isFalse);
     expect(state.hideStickyForumOverrides, isEmpty);
@@ -310,6 +311,23 @@ void main() {
     expect(store.get<String>('postListDensity'), 'compact');
   });
 
+  test('setCompactListFullBleed persists to settings store', () async {
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(store: store, initial: const AppSettings()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(settingsProvider).compactListFullBleed, isFalse);
+    container.read(settingsProvider.notifier).setCompactListFullBleed(true);
+    expect(container.read(settingsProvider).compactListFullBleed, isTrue);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(store.get<bool>('compactListFullBleed'), isTrue);
+  });
+
   test('setThreadListFiltersExpanded persists', () async {
     final container = ProviderContainer(
       overrides: [
@@ -345,6 +363,7 @@ void main() {
             initial: const AppSettings(
               threadListDensity: ListDensity.compact,
               postListDensity: ListDensity.compact,
+              compactListFullBleed: true,
               threadListFiltersExpanded: false,
             ),
           ),
@@ -357,6 +376,7 @@ void main() {
     final state = container.read(settingsProvider);
     expect(state.threadListDensity, ListDensity.standard);
     expect(state.postListDensity, ListDensity.standard);
+    expect(state.compactListFullBleed, isFalse);
     expect(state.threadListFiltersExpanded, isFalse);
   });
 

--- a/test/services/s1_backup_service_test.dart
+++ b/test/services/s1_backup_service_test.dart
@@ -114,6 +114,7 @@ void main() {
         'shareAdvancedExport': true,
         'threadListDensity': 'compact',
         'postListDensity': 'standard',
+        'compactListFullBleed': true,
         'threadListFiltersExpanded': false,
         'hideStickyThreads': true,
         'hideStickyForumOverrides': {'4', '9'},
@@ -131,6 +132,7 @@ void main() {
       expect(backup['share_advanced_export'], isTrue);
       expect(backup['thread_list_density'], 'compact');
       expect(backup['post_list_density'], 'standard');
+      expect(backup['compact_list_full_bleed'], isTrue);
       expect(backup['thread_list_filters_expanded'], isFalse);
       expect(backup['hide_sticky_threads'], isTrue);
       expect(
@@ -155,6 +157,7 @@ void main() {
       expect(app['shareImageFormat'], 'webp');
       expect(app['sharePixelRatio'], 2);
       expect(app['shareAdvancedExport'], isTrue);
+      expect(app['compactListFullBleed'], isTrue);
       expect(app['hiddenForums'], ['75', '6']);
       expect(app['hideStickyThreads'], isTrue);
       expect(app['hideStickyForumOverrides'], ['4', '9']);

--- a/test/theme/s1_reading_card_style_test.dart
+++ b/test/theme/s1_reading_card_style_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1er/theme/app_theme.dart';
+import 'package:s1er/theme/s1_reading_card_style.dart';
+
+void main() {
+  Future<BuildContext> pumpAt(WidgetTester tester, {required Size size}) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    late BuildContext captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            captured = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return captured;
+  }
+
+  testWidgets('compact + enabled is full-bleed', (tester) async {
+    final context = await pumpAt(tester, size: const Size(400, 800));
+    expect(S1ReadingCardStyle.isFullBleed(context, enabled: true), isTrue);
+    expect(
+      S1ReadingCardStyle.margin(context, enabled: true, vertical: 4),
+      const EdgeInsets.symmetric(vertical: 4),
+    );
+    expect(
+      S1ReadingCardStyle.inkBorderRadius(context, enabled: true),
+      BorderRadius.zero,
+    );
+    final shape = S1ReadingCardStyle.shape(context, enabled: true)
+        as RoundedRectangleBorder;
+    expect(shape.borderRadius, BorderRadius.zero);
+    expect(shape.side, BorderSide.none);
+  });
+
+  testWidgets('compact + disabled keeps floating card', (tester) async {
+    final context = await pumpAt(tester, size: const Size(400, 800));
+    expect(S1ReadingCardStyle.isFullBleed(context, enabled: false), isFalse);
+    expect(
+      S1ReadingCardStyle.margin(context, enabled: false, vertical: 5),
+      const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+    );
+    expect(
+      S1ReadingCardStyle.inkBorderRadius(context, enabled: false),
+      S1Shape.medium,
+    );
+  });
+
+  testWidgets('medium + enabled still keeps floating card', (tester) async {
+    final context = await pumpAt(tester, size: const Size(800, 800));
+    expect(S1ReadingCardStyle.isFullBleed(context, enabled: true), isFalse);
+    expect(
+      S1ReadingCardStyle.margin(context, enabled: true, vertical: 4),
+      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    );
+    expect(
+      S1ReadingCardStyle.inkBorderRadius(context, enabled: true),
+      S1Shape.medium,
+    );
+  });
+
+  testWidgets('full-bleed selected outline keeps zero radius', (tester) async {
+    final context = await pumpAt(tester, size: const Size(400, 800));
+    final shape = S1ReadingCardStyle.shape(
+      context,
+      enabled: true,
+      side: const BorderSide(width: 1.5),
+    ) as RoundedRectangleBorder;
+    expect(shape.borderRadius, BorderRadius.zero);
+    expect(shape.side.width, 1.5);
+  });
+}

--- a/test/widgets/post_item_density_test.dart
+++ b/test/widgets/post_item_density_test.dart
@@ -22,13 +22,17 @@ void main() {
   Future<void> pumpPost(
     WidgetTester tester, {
     required ListDensity density,
+    bool compactListFullBleed = false,
   }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           settingsProvider.overrideWith(
             () => SettingsNotifier(
-              initial: AppSettings(postListDensity: density),
+              initial: AppSettings(
+                postListDensity: density,
+                compactListFullBleed: compactListFullBleed,
+              ),
             ),
           ),
         ],
@@ -98,5 +102,22 @@ void main() {
       PostItemDensityTokens.forDensity(ListDensity.compact).headerActionExtent,
       32,
     );
+  });
+
+  testWidgets('compact full-bleed drops post card side margin and radius',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpPost(
+      tester,
+      density: ListDensity.standard,
+      compactListFullBleed: true,
+    );
+    final card = tester.widget<Card>(find.byType(Card).first);
+    expect(card.margin, const EdgeInsets.symmetric(vertical: 4));
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.borderRadius, BorderRadius.zero);
   });
 }

--- a/test/widgets/s1_list_skeletons_test.dart
+++ b/test/widgets/s1_list_skeletons_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:s1er/theme/app_theme.dart';
 import 'package:s1er/widgets/skeleton/forum_index_skeleton.dart';
@@ -11,9 +12,11 @@ import 'package:s1er/widgets/thread_locate_skeleton.dart';
 
 void main() {
   Widget wrap(Widget child) {
-    return MaterialApp(
-      theme: AppTheme.lightTheme('purple'),
-      home: Scaffold(body: child),
+    return ProviderScope(
+      child: MaterialApp(
+        theme: AppTheme.lightTheme('purple'),
+        home: Scaffold(body: child),
+      ),
     );
   }
 

--- a/test/widgets/thread_card_test.dart
+++ b/test/widgets/thread_card_test.dart
@@ -6,6 +6,7 @@ import 'package:s1er/models/reading_record.dart';
 import 'package:s1er/models/thread.dart';
 import 'package:s1er/providers/reading_history_provider.dart';
 import 'package:s1er/providers/settings_provider.dart';
+import 'package:s1er/theme/app_theme.dart';
 import 'package:s1er/widgets/thread_card.dart';
 
 import '../helpers/test_theme.dart';
@@ -27,6 +28,7 @@ void main() {
   Future<void> pumpCard(
     WidgetTester tester, {
     required ListDensity density,
+    bool compactListFullBleed = false,
     Thread? thread,
     String? selectedTypeId,
     ThreadTypeFilterCallback? onTypeFilter,
@@ -38,7 +40,10 @@ void main() {
         overrides: [
           settingsProvider.overrideWith(
             () => SettingsNotifier(
-              initial: AppSettings(threadListDensity: density),
+              initial: AppSettings(
+                threadListDensity: density,
+                compactListFullBleed: compactListFullBleed,
+              ),
             ),
           ),
           readingRecordProvider(t.tid).overrideWithValue(record),
@@ -406,5 +411,57 @@ void main() {
 
     expect(find.text('青黑无脑'), findsOneWidget);
     expect(find.text('青黑无脑不要游戏只求一战'), findsNothing);
+  });
+
+  testWidgets('compact full-bleed drops side margin and radius',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpCard(
+      tester,
+      density: ListDensity.standard,
+      compactListFullBleed: true,
+    );
+
+    final card = tester.widget<Card>(find.byType(Card).first);
+    expect(card.margin, const EdgeInsets.symmetric(vertical: 5));
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.borderRadius, BorderRadius.zero);
+  });
+
+  testWidgets('full-bleed setting ignored on medium windows', (tester) async {
+    tester.view.physicalSize = const Size(800, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(
+              initial: const AppSettings(compactListFullBleed: true),
+            ),
+          ),
+          readingRecordProvider(sampleThread.tid).overrideWithValue(null),
+        ],
+        child: wrapWithAppTheme(
+          SizedBox(
+            width: 800,
+            child: ThreadCard(thread: sampleThread),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final card = tester.widget<Card>(find.byType(Card).first);
+    expect(
+      card.margin,
+      const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+    );
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.borderRadius, S1Shape.medium);
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把主题列表和楼层卡片的「窄屏去边距/圆角」做成浏览设置，默认关闭，现有效果不变。

## 行为

- 新开关 **窄屏列表铺满**（浏览行为，默认关），放在列表密度上方
- 打开后仅在 compact 窗口（宽度 ≤599，一般是竖屏手机）生效：卡片左右 margin 与圆角为 0，卡内 padding 保留
- 更宽的窗口（平板、桌面、阅读列）即使开了开关仍用圆角卡片
- 与列表密度分开：密度管行高，本项管左右几何

## 范围

主题列表、帖内楼层、投票卡、屏蔽占位、对应骨架。设置页 / 私信 / 搜索 / 阅读历史未改。

## 测试

`S1ReadingCardStyle`、ThreadCard / PostItem、settings 持久化与重置、备份 round-trip。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

