### PR TITLE
feat(theme): 深色阅读面少抬一档

### DIFF
--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -1695,7 +1695,7 @@ class _BlockedPostPlaceholder extends ConsumerWidget {
         vertical: tokens.cardMarginVertical,
       ),
       elevation: 0,
-      color: S1Surface.card(scheme),
+      color: S1Surface.reading(scheme),
       shape: S1ReadingCardStyle.shape(
         context,
         enabled: compactListFullBleed,

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -38,10 +38,12 @@ abstract class S1Shape {
 /// 1. **画布** [page] = [ColorScheme.surfaceContainerHighest]（`#EDE0D4`）
 /// 2. **内容浮层** [card] = [ColorScheme.surfaceContainerLow]（`#FFF1E5` 奶油沙；
 ///    Reply 未选中列表卡用 `surfaceVariant`≈此档，避免 `surface` 过白）
-/// 3. **卡内嵌套** [nestedPanel] / [nestedPanelItem] = High / Highest（评分区等）
-/// 4. **强调** = `primaryContainer`（选中）/ `secondaryContainer`（打开）等
+/// 3. **阅读面** [reading] = 与 [card] 同档 Low（主题列表 / 楼层）
+/// 4. **卡内嵌套** [nestedPanel] / [nestedPanelItem] = High / Highest（评分区等）
+/// 5. **强调** = `primaryContainer`（选中）/ `secondaryContainer`（打开）等
 ///
-/// 深色：page=Lowest，card=High，nestedPanel=Low，nestedPanelItem=Highest。
+/// 深色：page=Lowest，reading=Low（少抬），card=High（设置等稀疏卡），
+/// nestedPanel=Container，nestedPanelItem=Highest。
 /// 弱浮层 [floatingControl]：浅色 High（对 Low 卡 / Highest 画布），深色 Highest（对 High 卡 / Lowest 画布）。
 /// FAB 用 `tertiaryContainer`（Reply 薄荷绿）。导航铬件与画布同色。
 abstract class S1Surface {
@@ -53,11 +55,14 @@ abstract class S1Surface {
       ? scheme.surfaceContainerLow
       : scheme.surfaceContainerHigh;
 
-  /// 贴在 [card] 内的嵌套面板（评分区等）：浅色更深、深色更浅，与帖卡拉开对比。
+  /// 主题列表 / 帖内楼层等大面积阅读底：浅色与 [card] 同档；深色只抬一档，避免灰灯板。
+  static Color reading(ColorScheme scheme) => scheme.surfaceContainerLow;
+
+  /// 贴在 [reading] 内的嵌套面板（评分区等）：浅色更深、深色略亮，与阅读面错开。
   static Color nestedPanel(ColorScheme scheme) =>
       scheme.brightness == Brightness.light
           ? scheme.surfaceContainerHigh
-          : scheme.surfaceContainerLow;
+          : scheme.surfaceContainer;
 
   /// 嵌套面板内的条目条：再偏一档，避免与面板糊成一片。
   static Color nestedPanelItem(ColorScheme scheme) =>

--- a/lib/widgets/poll_card.dart
+++ b/lib/widgets/poll_card.dart
@@ -125,7 +125,7 @@ class _PollCardState extends ConsumerState<PollCard> {
         vertical: 4,
       ),
       elevation: 0,
-      color: S1Surface.card(scheme),
+      color: S1Surface.reading(scheme),
       shape: S1ReadingCardStyle.shape(
         context,
         enabled: compactListFullBleed,

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -259,7 +259,7 @@ class _PostItemState extends ConsumerState<PostItem>
           ? scheme.secondaryContainer.withValues(alpha: S1Alpha.half)
           : widget.isHighlighted
               ? scheme.primaryContainer.withValues(alpha: S1Alpha.half)
-              : S1Surface.card(scheme),
+              : S1Surface.reading(scheme),
       shape: S1ReadingCardStyle.shape(
         context,
         enabled: compactListFullBleed,

--- a/lib/widgets/skeleton/s1_skeleton_shapes.dart
+++ b/lib/widgets/skeleton/s1_skeleton_shapes.dart
@@ -10,7 +10,7 @@ abstract class S1SkeletonShapes {
 
   static Color barColor(ColorScheme scheme) => scheme.surfaceContainerHighest;
 
-  static Color cardColor(ColorScheme scheme) => scheme.surfaceContainerLow;
+  static Color cardColor(ColorScheme scheme) => S1Surface.reading(scheme);
 }
 
 class S1SkeletonBar extends StatelessWidget {

--- a/lib/widgets/thread_card.dart
+++ b/lib/widgets/thread_card.dart
@@ -243,7 +243,7 @@ class ThreadCard extends ConsumerWidget {
             ? scheme.secondaryContainer
             : isSticky
                 ? scheme.primaryContainer
-                : S1Surface.card(scheme),
+                : S1Surface.reading(scheme),
         shape: S1ReadingCardStyle.shape(
           context,
           enabled: compactListFullBleed,

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -98,6 +98,11 @@ void main() {
         light.floatingActionButtonTheme.backgroundColor,
         lightScheme.tertiaryContainer,
       );
+      expect(
+        S1Surface.reading(lightScheme),
+        lightScheme.surfaceContainerLow,
+      );
+      expect(S1Surface.reading(lightScheme), S1Surface.card(lightScheme));
       // 卡内嵌套：浅色 High/Highest，深于 Low 帖卡。
       expect(
         S1Surface.nestedPanel(lightScheme),
@@ -110,6 +115,10 @@ void main() {
       expect(
         S1Surface.nestedPanel(lightScheme),
         isNot(S1Surface.card(lightScheme)),
+      );
+      expect(
+        S1Surface.nestedPanel(lightScheme),
+        isNot(S1Surface.reading(lightScheme)),
       );
       // 弱浮层：与帖卡、画布均错开。
       expect(
@@ -130,13 +139,25 @@ void main() {
       expect(dark.scaffoldBackgroundColor, darkScheme.surfaceContainerLowest);
       expect(dark.cardTheme.color, darkScheme.surfaceContainerHigh);
       expect(
+        S1Surface.reading(darkScheme),
+        darkScheme.surfaceContainerLow,
+      );
+      expect(
+        S1Surface.reading(darkScheme).computeLuminance(),
+        greaterThan(S1Surface.page(darkScheme).computeLuminance()),
+      );
+      expect(
+        S1Surface.reading(darkScheme).computeLuminance(),
+        lessThan(S1Surface.card(darkScheme).computeLuminance()),
+      );
+      expect(
         S1BottomBarStyle.background(darkScheme),
         darkScheme.surfaceContainerLowest,
       );
-      // 深色嵌套：Low 面板亮于 High 帖卡；条目 Highest 再沉一档。
+      // 深色嵌套：Container 略亮于 Low 阅读面；条目 Highest 再抬一档。
       expect(
         S1Surface.nestedPanel(darkScheme),
-        darkScheme.surfaceContainerLow,
+        darkScheme.surfaceContainer,
       );
       expect(
         S1Surface.nestedPanelItem(darkScheme),
@@ -145,6 +166,10 @@ void main() {
       expect(
         S1Surface.nestedPanel(darkScheme),
         isNot(S1Surface.card(darkScheme)),
+      );
+      expect(
+        S1Surface.nestedPanel(darkScheme),
+        isNot(S1Surface.reading(darkScheme)),
       );
       expect(
         S1Surface.floatingControl(darkScheme),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
深色主题下，主题列表和帖内楼层不再用明显抬亮的 `surfaceContainerHigh`，改走更接近画布的阅读面。浅色不变。不做设置项。

## 色阶

- 新增 `S1Surface.reading`：浅色 / 深色都是 `surfaceContainerLow`
- 深色阅读卡相对画布（`Lowest`）只抬一档，避免大面积灰灯板
- `S1Surface.card` 仍为深色 `High`（设置卡、搜索栏等稀疏浮层不动）
- 深色评分嵌套 `nestedPanel`：`Low` → `Container`，避免和阅读卡同色

## 范围

主题列表、帖内楼层、投票卡、屏蔽占位、对应骨架。置顶 / 选中 / 高亮仍用 container 色。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

