### PR TITLE
feat(theme): 深色阅读面抬到 Container

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -42,8 +42,8 @@ abstract class S1Shape {
 /// 4. **卡内嵌套** [nestedPanel] / [nestedPanelItem] = High / Highest（评分区等）
 /// 5. **强调** = `primaryContainer`（选中）/ `secondaryContainer`（打开）等
 ///
-/// 深色：page=Lowest，reading=Low（少抬），card=High（设置等稀疏卡），
-/// nestedPanel=Container，nestedPanelItem=Highest。
+/// 深色：page=Lowest，reading=Container（OLED/LCD 折中；低于 High 灯板），
+/// card=High（设置等稀疏卡），nestedPanel=High，nestedPanelItem=Highest。
 /// 弱浮层 [floatingControl]：浅色 High（对 Low 卡 / Highest 画布），深色 Highest（对 High 卡 / Lowest 画布）。
 /// FAB 用 `tertiaryContainer`（Reply 薄荷绿）。导航铬件与画布同色。
 abstract class S1Surface {
@@ -55,14 +55,15 @@ abstract class S1Surface {
       ? scheme.surfaceContainerLow
       : scheme.surfaceContainerHigh;
 
-  /// 主题列表 / 帖内楼层等大面积阅读底：浅色与 [card] 同档；深色只抬一档，避免灰灯板。
-  static Color reading(ColorScheme scheme) => scheme.surfaceContainerLow;
+  /// 主题列表 / 帖内楼层等大面积阅读底：浅色与 [card] 同档 Low；
+  /// 深色用 Container（低于 [card] 的 High，高于画布邻档 Low，兼顾 OLED 近黑压阶与 LCD 灯板）。
+  static Color reading(ColorScheme scheme) =>
+      scheme.brightness == Brightness.light
+          ? scheme.surfaceContainerLow
+          : scheme.surfaceContainer;
 
   /// 贴在 [reading] 内的嵌套面板（评分区等）：浅色更深、深色略亮，与阅读面错开。
-  static Color nestedPanel(ColorScheme scheme) =>
-      scheme.brightness == Brightness.light
-          ? scheme.surfaceContainerHigh
-          : scheme.surfaceContainer;
+  static Color nestedPanel(ColorScheme scheme) => scheme.surfaceContainerHigh;
 
   /// 嵌套面板内的条目条：再偏一档，避免与面板糊成一片。
   static Color nestedPanelItem(ColorScheme scheme) =>

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -140,7 +140,11 @@ void main() {
       expect(dark.cardTheme.color, darkScheme.surfaceContainerHigh);
       expect(
         S1Surface.reading(darkScheme),
-        darkScheme.surfaceContainerLow,
+        darkScheme.surfaceContainer,
+      );
+      expect(
+        S1Surface.reading(darkScheme),
+        isNot(darkScheme.surfaceContainerLow),
       );
       expect(
         S1Surface.reading(darkScheme).computeLuminance(),
@@ -154,10 +158,10 @@ void main() {
         S1BottomBarStyle.background(darkScheme),
         darkScheme.surfaceContainerLowest,
       );
-      // 深色嵌套：Container 略亮于 Low 阅读面；条目 Highest 再抬一档。
+      // 深色嵌套：High 亮于 Container 阅读面（与 card 同档）；条目 Highest 再抬一档。
       expect(
         S1Surface.nestedPanel(darkScheme),
-        darkScheme.surfaceContainer,
+        darkScheme.surfaceContainerHigh,
       );
       expect(
         S1Surface.nestedPanelItem(darkScheme),
@@ -165,7 +169,7 @@ void main() {
       );
       expect(
         S1Surface.nestedPanel(darkScheme),
-        isNot(S1Surface.card(darkScheme)),
+        S1Surface.card(darkScheme),
       );
       expect(
         S1Surface.nestedPanel(darkScheme),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#35 把深色主题列表 / 楼层从 `High` 降到 `Low` 后，OLED 上卡和画布容易糊，LCD / Web 上又偏亮。这次把阅读面改到中间档 `surfaceContainer`，给多平台实机对比。

## 色阶（仅深色）

- `S1Surface.reading`：`Low` → `Container`（主题列表、楼层、投票卡、屏蔽占位、骨架）
- `S1Surface.nestedPanel`：`Container` → `High`，评分区仍高于阅读面
- `S1Surface.card` 仍为 `High`（首页分组、设置等不动）
- 浅色不变

## 怎么验

请在 OLED 手机、LCD（如 Windows / Surface Web）上对比主题列表和帖内楼层：卡要能从画布分出来，又不要回到 #35 之前的灰灯板。首页和设置不应有变化。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

