### PR TITLE
feat(theme): 深色内容卡与阅读面统一为 Container

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -36,15 +36,15 @@ abstract class S1Shape {
 ///
 /// 浅色（与 Reply `Color.kt` / 列表卡用法一致的可映射关系）：
 /// 1. **画布** [page] = [ColorScheme.surfaceContainerHighest]（`#EDE0D4`）
-/// 2. **内容浮层** [card] = [ColorScheme.surfaceContainerLow]（`#FFF1E5` 奶油沙；
-///    Reply 未选中列表卡用 `surfaceVariant`≈此档，避免 `surface` 过白）
-/// 3. **阅读面** [reading] = 与 [card] 同档 Low（主题列表 / 楼层）
-/// 4. **卡内嵌套** [nestedPanel] / [nestedPanelItem] = High / Highest（评分区等）
-/// 5. **强调** = `primaryContainer`（选中）/ `secondaryContainer`（打开）等
+/// 2. **内容卡 / 阅读面** [card] / [reading] = [ColorScheme.surfaceContainerLow]
+///    （`#FFF1E5` 奶油沙；Reply 未选中列表卡用 `surfaceVariant`≈此档）
+/// 3. **卡内嵌套** [nestedPanel] / [nestedPanelItem] = High / Highest（评分区等）
+/// 4. **强调** = `primaryContainer`（选中）/ `secondaryContainer`（打开）等
 ///
-/// 深色：page=Lowest，reading=Container（OLED/LCD 折中；低于 High 灯板），
-/// card=High（设置等稀疏卡），nestedPanel=High，nestedPanelItem=Highest。
-/// 弱浮层 [floatingControl]：浅色 High（对 Low 卡 / Highest 画布），深色 Highest（对 High 卡 / Lowest 画布）。
+/// 深色：page=Lowest，card=reading=Container（分组卡与阅读面同一档），
+/// nestedPanel=High，nestedPanelItem=Highest。
+/// 弱浮层 [floatingControl]：浅色 High（对 Low 卡 / Highest 画布），
+/// 深色 Highest（对 Container 卡 / Lowest 画布）。
 /// FAB 用 `tertiaryContainer`（Reply 薄荷绿）。导航铬件与画布同色。
 abstract class S1Surface {
   static Color page(ColorScheme scheme) => scheme.brightness == Brightness.light
@@ -53,14 +53,10 @@ abstract class S1Surface {
 
   static Color card(ColorScheme scheme) => scheme.brightness == Brightness.light
       ? scheme.surfaceContainerLow
-      : scheme.surfaceContainerHigh;
+      : scheme.surfaceContainer;
 
-  /// 主题列表 / 帖内楼层等大面积阅读底：浅色与 [card] 同档 Low；
-  /// 深色用 Container（低于 [card] 的 High，高于画布邻档 Low，兼顾 OLED 近黑压阶与 LCD 灯板）。
-  static Color reading(ColorScheme scheme) =>
-      scheme.brightness == Brightness.light
-          ? scheme.surfaceContainerLow
-          : scheme.surfaceContainer;
+  /// 主题列表 / 帖内楼层等大面积阅读底：与 [card] 同档。
+  static Color reading(ColorScheme scheme) => card(scheme);
 
   /// 贴在 [reading] 内的嵌套面板（评分区等）：浅色更深、深色略亮，与阅读面错开。
   static Color nestedPanel(ColorScheme scheme) => scheme.surfaceContainerHigh;

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -137,28 +137,29 @@ void main() {
       final dark = AppTheme.darkTheme('sand');
       final darkScheme = dark.colorScheme;
       expect(dark.scaffoldBackgroundColor, darkScheme.surfaceContainerLowest);
-      expect(dark.cardTheme.color, darkScheme.surfaceContainerHigh);
+      expect(dark.cardTheme.color, darkScheme.surfaceContainer);
       expect(
         S1Surface.reading(darkScheme),
         darkScheme.surfaceContainer,
       );
+      expect(S1Surface.reading(darkScheme), S1Surface.card(darkScheme));
       expect(
         S1Surface.reading(darkScheme),
         isNot(darkScheme.surfaceContainerLow),
+      );
+      expect(
+        S1Surface.reading(darkScheme),
+        isNot(darkScheme.surfaceContainerHigh),
       );
       expect(
         S1Surface.reading(darkScheme).computeLuminance(),
         greaterThan(S1Surface.page(darkScheme).computeLuminance()),
       );
       expect(
-        S1Surface.reading(darkScheme).computeLuminance(),
-        lessThan(S1Surface.card(darkScheme).computeLuminance()),
-      );
-      expect(
         S1BottomBarStyle.background(darkScheme),
         darkScheme.surfaceContainerLowest,
       );
-      // 深色嵌套：High 亮于 Container 阅读面（与 card 同档）；条目 Highest 再抬一档。
+      // 深色嵌套：High 亮于 Container 内容卡；条目 Highest 再抬一档。
       expect(
         S1Surface.nestedPanel(darkScheme),
         darkScheme.surfaceContainerHigh,
@@ -169,7 +170,7 @@ void main() {
       );
       expect(
         S1Surface.nestedPanel(darkScheme),
-        S1Surface.card(darkScheme),
+        isNot(S1Surface.card(darkScheme)),
       );
       expect(
         S1Surface.nestedPanel(darkScheme),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
阅读面改到 `Container` 后，把其它内容卡收到同一档，深色下首页 / 设置 / 资料和主题列表不再两套深浅。

## 改动

- 深色 `S1Surface.card`：`High` → `Container`，与 `reading` 同色
- 走 `cardTheme` 或 `S1Surface.card` 的卡都会跟上（首页分组、设置、资料、搜索、历史、私信列表、分享卡等）
- 评分嵌套仍为 `High`，比内容卡亮一档
- 浅色不变

未改：私信气泡、引用/代码块、弹层和输入凹槽、置顶高亮。

## 怎么验

深色下从论坛首页进版面、再看「我的」和设置：卡片应与主题列表同一深浅。OLED 和 LCD / Web 都看一眼。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

