### PR TITLE
fix(ui): 分类标签垂直居中，去掉定位时的近白底

### DIFF
--- a/lib/screens/pm_conversation_screen.dart
+++ b/lib/screens/pm_conversation_screen.dart
@@ -126,7 +126,7 @@ class _PmComposer extends StatelessWidget {
     return SafeArea(
       top: false,
       child: Material(
-        color: isDesktop ? scheme.surface : scheme.surfaceContainer,
+        color: isDesktop ? S1Surface.page(scheme) : scheme.surfaceContainer,
         child: isDesktop
             ? Center(
                 child: ConstrainedBox(

--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -1413,7 +1413,7 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
             children: [
               if (widget.suppressAppBar && _shareSelectMode)
                 Material(
-                  color: scheme.surface,
+                  color: S1Surface.page(scheme),
                   elevation: 0,
                   child: SafeArea(
                     bottom: false,

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -321,6 +321,8 @@ class AppTheme {
       textTheme: textTheme,
       primaryTextTheme: textTheme,
       scaffoldBackgroundColor: S1Surface.page(colorScheme),
+      // 默认 Material / 路由空隙走画布，避免浅色 `scheme.surface` 近白闪一下。
+      canvasColor: S1Surface.page(colorScheme),
       appBarTheme: AppBarTheme(
         centerTitle: true,
         elevation: 0,

--- a/lib/utils/compact_label.dart
+++ b/lib/utils/compact_label.dart
@@ -2,12 +2,20 @@ import 'package:flutter/material.dart';
 
 /// 紧凑标签文字样式工具。
 ///
-/// 为 [Chip] / [Badge] 等紧凑容器提供一致的 [labelSmall] 样式；
-/// 使用平台默认行高，不做额外偏移补偿。
+/// 为 [Chip] / [Badge] 等紧凑容器提供一致的 [labelSmall] 样式。
+/// 收紧 ascent/descent 额外留白；表意文字再做轻微光学上移（与头像 fallback 同因）。
 abstract final class CompactLabel {
-  static const textHeightBehavior = TextHeightBehavior();
+  /// 不把行高加到首行 ascent / 末行 descent，避免字盒高于墨水区。
+  static const textHeightBehavior = TextHeightBehavior(
+    applyHeightToFirstAscent: false,
+    applyHeightToLastDescent: false,
+  );
 
+  /// 显式传入 [text] 的 `nudge` 时的基准；默认无额外全局偏移。
   static const visualNudge = Offset.zero;
+
+  /// 表意文字相对字号的光学上移（与头像首字母占位同系数）。
+  static const ideographicNudgeFactor = 0.06;
 
   static TextStyle style(
     BuildContext context, {
@@ -31,8 +39,28 @@ abstract final class CompactLabel {
       style: style,
       textHeightBehavior: textHeightBehavior,
     );
-    final offset = nudge ?? visualNudge;
+    final offset = nudge ?? _autoNudge(data, style);
     if (offset == Offset.zero) return child;
     return Transform.translate(offset: offset, child: child);
+  }
+
+  /// 含中日韩表意/音节文字时，字形铺满 em 盒，视觉重心常低于拉丁字母。
+  static bool containsIdeographic(String data) {
+    for (final c in data.runes) {
+      if ((c >= 0x2E80 && c <= 0x9FFF) ||
+          (c >= 0xAC00 && c <= 0xD7AF) ||
+          (c >= 0xF900 && c <= 0xFAFF) ||
+          (c >= 0xFF00 && c <= 0xFFEF) ||
+          (c >= 0x20000 && c <= 0x2FA1F)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static Offset _autoNudge(String data, TextStyle style) {
+    if (!containsIdeographic(data)) return visualNudge;
+    final size = style.fontSize ?? 11;
+    return Offset(0, -size * ideographicNudgeFactor);
   }
 }

--- a/lib/widgets/thread_locate_skeleton.dart
+++ b/lib/widgets/thread_locate_skeleton.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../theme/app_theme.dart';
 import 'skeleton/post_item_skeleton.dart';
 
 /// 帖子详情楼层定位期间的占位骨架（遮在真列表之上，定位完成后移除）。
@@ -10,7 +11,7 @@ class ThreadLocateSkeleton extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return ColoredBox(
-      color: scheme.surface,
+      color: S1Surface.page(scheme),
       child: ListView(
         physics: const NeverScrollableScrollPhysics(),
         padding: const EdgeInsets.symmetric(vertical: 8),

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -77,6 +77,8 @@ void main() {
         light.scaffoldBackgroundColor,
         lightScheme.surfaceContainerHighest,
       );
+      expect(light.canvasColor, S1Surface.page(lightScheme));
+      expect(light.canvasColor, isNot(lightScheme.surface));
       expect(light.cardTheme.color, lightScheme.surfaceContainerLow);
       expect(
         light.appBarTheme.backgroundColor,
@@ -137,6 +139,7 @@ void main() {
       final dark = AppTheme.darkTheme('sand');
       final darkScheme = dark.colorScheme;
       expect(dark.scaffoldBackgroundColor, darkScheme.surfaceContainerLowest);
+      expect(dark.canvasColor, S1Surface.page(darkScheme));
       expect(dark.cardTheme.color, darkScheme.surfaceContainer);
       expect(
         S1Surface.reading(darkScheme),

--- a/test/utils/compact_label_test.dart
+++ b/test/utils/compact_label_test.dart
@@ -27,9 +27,69 @@ void main() {
     final text = tester.widget<Text>(find.text('8页'));
     expect(text.style?.height, themeLabelSmall.height);
     expect(text.textHeightBehavior, CompactLabel.textHeightBehavior);
+    expect(text.textHeightBehavior?.applyHeightToFirstAscent, isFalse);
+    expect(text.textHeightBehavior?.applyHeightToLastDescent, isFalse);
   });
 
-  test('visualNudge is zero (no default offset)', () {
+  test('visualNudge is zero (no default global offset)', () {
     expect(CompactLabel.visualNudge, Offset.zero);
+  });
+
+  test('containsIdeographic detects CJK but not latin', () {
+    expect(CompactLabel.containsIdeographic('新闻'), isTrue);
+    expect(CompactLabel.containsIdeographic('其他'), isTrue);
+    expect(CompactLabel.containsIdeographic('PC'), isFalse);
+    expect(CompactLabel.containsIdeographic('8页'), isTrue);
+  });
+
+  testWidgets('CompactLabel.text nudges ideographic labels up', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme('sand'),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: CompactLabel.text(
+                '新闻',
+                style: CompactLabel.style(context),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    final translate = tester.widget<Transform>(
+      find.ancestor(
+        of: find.text('新闻'),
+        matching: find.byType(Transform),
+      ),
+    );
+    final dy = translate.transform.getTranslation().y;
+    expect(dy, lessThan(0));
+  });
+
+  testWidgets('CompactLabel.text does not nudge latin labels', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme('sand'),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: CompactLabel.text(
+                'PC',
+                style: CompactLabel.style(context),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(
+      find.ancestor(of: find.text('PC'), matching: find.byType(Transform)),
+      findsNothing,
+    );
+    expect(find.text('PC'), findsOneWidget);
   });
 }

--- a/test/widgets/s1_list_skeletons_test.dart
+++ b/test/widgets/s1_list_skeletons_test.dart
@@ -38,6 +38,24 @@ void main() {
     expect(find.text('skeleton-item'), findsNWidgets(4));
   });
 
+  testWidgets('ThreadLocateSkeleton uses page surface not scheme.surface',
+      (tester) async {
+    await tester.pumpWidget(wrap(const ThreadLocateSkeleton()));
+    await tester.pump();
+
+    final scheme = AppTheme.lightTheme('purple').colorScheme;
+    final box = tester.widget<ColoredBox>(
+      find
+          .descendant(
+            of: find.byType(ThreadLocateSkeleton),
+            matching: find.byType(ColoredBox),
+          )
+          .first,
+    );
+    expect(box.color, S1Surface.page(scheme));
+    expect(box.color, isNot(scheme.surface));
+  });
+
   testWidgets('list skeleton widgets pump without error', (tester) async {
     const widgets = <Widget>[
       S1AsyncListLoading(child: PostItemSkeletonList()),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 分类标签

中文在 Chip 里视觉重心偏低（表意字铺满 em 盒），英文没有这个问题。`CompactLabel` 与头像 fallback 对齐：收紧 ascent/descent 留白，并对含 CJK 的标签做约 6% 字号的光学上移。

## 近白底

浅色 `ColorScheme.surface` 接近纯白，画布是 `surfaceContainerHighest`（暖沙）。横滑邻页已经走 `S1Surface.page` + 骨架；还漏了几处：

- **帖内定位骨架**（回复后 `locatePid` / 跳楼）：整页盖一层 `scheme.surface`，这就是最近「刷新时闪一下浅白」最像的路径
- 嵌入详情分享多选顶栏
- 桌面私信输入区衬底
- `ThemeData.canvasColor` 未覆盖时，默认 Material / 路由空隙也会落到 `surface`

以上改为 `S1Surface.page`。横滑骨架、列表首载骨架本身已是画布色，未改。

弹层 / 对话框仍用容器色阶，不是这次的近白闪。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

