### PR TITLE
feat(thread): 帖内列表支持下拉刷新

### DIFF
--- a/lib/screens/thread_detail_screen.dart
+++ b/lib/screens/thread_detail_screen.dart
@@ -1041,6 +1041,48 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
     );
   }
 
+  Widget _buildPostPageList(
+    ScrollController scrollController,
+    PostListState state,
+    List<({Post post, int originalIndex})> visible,
+    bool hasPageQuery,
+  ) {
+    const physics = AlwaysScrollableScrollPhysics();
+    if (state.posts.isEmpty) {
+      return ListView(
+        controller: scrollController,
+        physics: physics,
+        children: const [
+          SizedBox(height: 48),
+          Center(child: Text('暂无回复')),
+        ],
+      );
+    }
+    if (visible.isEmpty && hasPageQuery) {
+      return ListView(
+        controller: scrollController,
+        physics: physics,
+        children: const [
+          SizedBox(height: 48),
+          Center(child: Text('本页无匹配回复')),
+        ],
+      );
+    }
+    return ListView.builder(
+      controller: scrollController,
+      physics: physics,
+      scrollCacheExtent: S1FabLayout.threadDetailScrollCacheExtent,
+      padding: S1FabLayout.threadDetailScrollBottomPadding,
+      itemCount: _detailItemCount(state, visible),
+      itemBuilder: (context, index) => _buildDetailItem(
+        context,
+        state,
+        visible,
+        index,
+      ),
+    );
+  }
+
   /// 抓拍当前阅读位并压入跳转栈；无可用页码时跳过（首屏 ?pid= 不入栈）。
   void _captureInThreadJump() {
     final state = ref.read(postProvider(widget.tid)).asData?.value;
@@ -1343,37 +1385,29 @@ class _ThreadDetailScreenState extends ConsumerState<ThreadDetailScreen> {
                   adjacentSkeletonStyle: S1SwipeAdjacentSkeletonStyle.postItem,
                   onScrollMetricsChanged: _onScrollMetricsChanged,
                   onPageChanged: _goToPage,
-                  pageBuilder: (context, scrollController) =>
-                      ScrollPointerGateHost(
-                    child: Scrollbar(
-                      controller: scrollController,
-                      child: state.posts.isEmpty
-                          ? const Center(child: Text('暂无回复'))
-                          : visible.isEmpty && hasPageQuery
-                              ? ListView(
-                                  controller: scrollController,
-                                  children: const [
-                                    SizedBox(height: 48),
-                                    Center(child: Text('本页无匹配回复')),
-                                  ],
-                                )
-                              : ListView.builder(
-                                  controller: scrollController,
-                                  scrollCacheExtent:
-                                      S1FabLayout.threadDetailScrollCacheExtent,
-                                  padding: S1FabLayout
-                                      .threadDetailScrollBottomPadding,
-                                  itemCount: _detailItemCount(state, visible),
-                                  itemBuilder: (context, index) =>
-                                      _buildDetailItem(
-                                    context,
-                                    state,
-                                    visible,
-                                    index,
-                                  ),
+                  pageBuilder: (context, scrollController) {
+                    final list = _buildPostPageList(
+                      scrollController,
+                      state,
+                      visible,
+                      hasPageQuery,
+                    );
+                    return ScrollPointerGateHost(
+                      child: Scrollbar(
+                        controller: scrollController,
+                        child: _shareSelectMode
+                            ? list
+                            : RefreshIndicator(
+                                onRefresh: () => S1Haptics.wrapRefresh(
+                                  () => ref
+                                      .read(postProvider(widget.tid).notifier)
+                                      .refresh(),
                                 ),
-                    ),
-                  ),
+                                child: list,
+                              ),
+                      ),
+                    );
+                  },
                 ),
                 if (showLocateOverlay)
                   const Positioned.fill(

--- a/test/screens/thread_detail_refresh_test.dart
+++ b/test/screens/thread_detail_refresh_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:s1er/models/post.dart';
+import 'package:s1er/providers/post_provider.dart';
+import 'package:s1er/providers/settings_provider.dart';
+import 'package:s1er/providers/thread_rate_logs_provider.dart';
+import 'package:s1er/screens/thread_detail_screen.dart';
+import 'package:s1er/theme/app_theme.dart';
+import 'package:s1er/widgets/app_bar_more_menu.dart';
+import 'package:s1er/models/rate_log.dart';
+
+import '../helpers/test_local_data.dart';
+
+class _TestThreadRateLogsNotifier extends ThreadRateLogsNotifier {
+  _TestThreadRateLogsNotifier(super.tid);
+
+  @override
+  Map<String, PostRateLog> build() => const {};
+}
+
+class _FakePostNotifier extends PostNotifier {
+  _FakePostNotifier(super.tid, {this.empty = false});
+
+  final bool empty;
+  int refreshCount = 0;
+
+  @override
+  Future<PostListState> build() async {
+    if (empty) {
+      return PostListState(
+        posts: const [],
+        currentPage: 1,
+        totalPages: 1,
+        perPage: 10,
+        totalReplies: 0,
+        threadSubject: '空帖',
+      );
+    }
+    return PostListState(
+      posts: [
+        Post(
+          pid: '1',
+          author: '用户',
+          authorId: '1',
+          message: '楼层正文',
+          dateline: 1700000000,
+          floor: 1,
+        ),
+      ],
+      currentPage: 1,
+      totalPages: 2,
+      perPage: 10,
+      totalReplies: 11,
+      threadSubject: '测试主题',
+    );
+  }
+
+  @override
+  Future<void> refresh() async {
+    refreshCount++;
+  }
+}
+
+Future<void> _pumpThread({
+  required WidgetTester tester,
+  required String tid,
+  required PostNotifier notifier,
+}) async {
+  final (db, local) = await openTestLocalData();
+  addTearDown(db.close);
+  await local.ensureReadingHistoryLoaded();
+  await local.ensureBlacklistLoaded();
+  await local.ensurePollVotesLoaded();
+
+  final router = GoRouter(
+    initialLocation: '/thread/$tid',
+    routes: [
+      GoRoute(
+        path: '/thread/:tid',
+        builder: (context, state) {
+          return ThreadDetailScreen(
+            tid: state.pathParameters['tid']!,
+            onDestinationChanged: (_) {},
+          );
+        },
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        localDataProvider.overrideWithValue(local),
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(
+            initial: const AppSettings(
+              showImages: false,
+              recordReadingHistory: false,
+            ),
+          ),
+        ),
+        threadRateLogsProvider(tid).overrideWith(
+          () => _TestThreadRateLogsNotifier(tid),
+        ),
+        postProvider(tid).overrideWith(() => notifier),
+      ],
+      child: MaterialApp.router(
+        theme: AppTheme.lightTheme('purple'),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('thread detail shows pull-to-refresh and keeps overflow refresh',
+      (tester) async {
+    final notifier = _FakePostNotifier('200');
+    await _pumpThread(tester: tester, tid: '200', notifier: notifier);
+
+    expect(find.text('楼层正文'), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    final moreMenuFinder = find.descendant(
+      of: find.byType(AppBarMoreMenu),
+      matching: find.byTooltip('更多操作'),
+    );
+    await tester.tap(moreMenuFinder);
+    await tester.pumpAndSettle();
+    expect(find.text('刷新'), findsOneWidget);
+  });
+
+  testWidgets('empty thread page list can overscroll for pull-to-refresh',
+      (tester) async {
+    final notifier = _FakePostNotifier('201', empty: true);
+    await _pumpThread(tester: tester, tid: '201', notifier: notifier);
+
+    expect(find.text('暂无回复'), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    final listView = tester.widget<ListView>(find.byType(ListView).first);
+    expect(listView.physics, isA<AlwaysScrollableScrollPhysics>());
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
帖内补下拉刷新，对齐版块列表。`⋮` 里的刷新保留，人在楼中仍走菜单。分页栏不加图标、也不做长按。

- 楼层列表外包 `RefreshIndicator`（`S1Haptics.wrapRefresh` → `postProvider.refresh`）
- 空帖 / 本页无匹配改为可滚动 `ListView` + `AlwaysScrollableScrollPhysics`，短列表也能下拉
- 多选分享模式不套下拉
- `skipLoadingOnReload` 已有，刷新不卸列表
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

