### PR TITLE
fix(ui): make post author smaller than body

### DIFF
--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -688,7 +688,7 @@ class _PostItemState extends ConsumerState<PostItem>
     final textTheme = Theme.of(context).textTheme;
     final scheme = Theme.of(context).colorScheme;
     final nameStyle =
-        textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold);
+        textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600);
     final timeStyle = textTheme.labelSmall?.copyWith(
       color: scheme.onSurfaceVariant,
     );

--- a/test/widgets/post_item_layout_test.dart
+++ b/test/widgets/post_item_layout_test.dart
@@ -7,6 +7,41 @@ import 'package:s1er/widgets/post_item.dart';
 import '../helpers/test_theme.dart';
 
 void main() {
+  testWidgets('PostItem author name is one step smaller than body',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: wrapWithAppTheme(
+          PostItem(
+            post: Post.fromJson({
+              'pid': 'author-type-1',
+              'message': 'body copy',
+              'author': 'AliceAuthor',
+              'authorid': '1',
+              'dbdateline': '1700001000',
+              'number': '1',
+            }),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final authorFinder = find.text('AliceAuthor');
+    expect(authorFinder, findsOneWidget);
+
+    final authorText = tester.widget<Text>(authorFinder);
+    final theme = Theme.of(tester.element(authorFinder));
+    final bodySmallSize = theme.textTheme.bodySmall?.fontSize;
+    final bodyMediumSize = theme.textTheme.bodyMedium?.fontSize;
+
+    expect(authorText.style?.fontSize, bodySmallSize);
+    expect(bodySmallSize, isNotNull);
+    expect(bodyMediumSize, isNotNull);
+    expect(bodySmallSize!, lessThan(bodyMediumSize!));
+    expect(authorText.style?.fontWeight, FontWeight.w600);
+  });
+
   testWidgets('PostItem avoids header overflow under narrow constraints',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
楼层用户名现在比正文小一档：`bodySmall`（12）+ `FontWeight.w600`，不再和楼层正文共用 `bodyMedium` + bold。

标准（两行）和紧凑（一行 `Text.rich`）共用同一 `nameStyle`。时间仍用 `labelSmall`。颜色跟 `onSurface`，不写死。

不改设置、字号四档、楼层密度、头像、分隔线、分享卡作者样式。

## 测试

`post_item_layout_test` 断言作者名字号等于 `textTheme.bodySmall`、小于 `bodyMedium`，字重为 `w600`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

