### PR TITLE
fix(home): return to forum tab before confirming exit

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../config/api_config.dart';
@@ -17,7 +18,9 @@ import '../models/notice_item.dart';
 import '../theme/app_theme.dart';
 import '../theme/s1_haptics.dart';
 import '../utils/forum_index_view.dart';
+import '../utils/home_root_back.dart';
 import '../utils/s1_snack_bar.dart';
+import '../widgets/s1_fab_layout.dart';
 import '../widgets/app_bar_more_menu.dart';
 import '../widgets/favorite_confirm_dialog.dart';
 import '../widgets/hide_forum_confirm_dialog.dart';
@@ -73,6 +76,50 @@ class _HomeScreenBody extends ConsumerStatefulWidget {
 
 class _HomeScreenBodyState extends ConsumerState<_HomeScreenBody> {
   int _fallbackTab = 0;
+  DateTime? _exitArmedAt;
+
+  void _handleHomeRootPop({
+    required bool didPop,
+    required bool isForumTab,
+    required bool isMessagesTab,
+    required GoRouter? router,
+    required bool showNavBar,
+  }) {
+    if (didPop) return;
+    final action = resolveHomeRootBack(
+      isForumTab: isForumTab,
+      now: DateTime.now(),
+      lastExitArmedAt: _exitArmedAt,
+      canExitApp: Theme.of(context).platform == TargetPlatform.android,
+    );
+    switch (action) {
+      case HomeRootBackAction.goForum:
+        _exitArmedAt = null;
+        if (isMessagesTab) {
+          ref.read(messagesSegmentProvider.notifier).select(0);
+        }
+        if (router == null) {
+          setState(() => _fallbackTab = 0);
+        } else {
+          context.go('/');
+        }
+      case HomeRootBackAction.armExit:
+        _exitArmedAt = DateTime.now();
+        S1SnackBar.show(
+          context,
+          message: HomeRootBack.snackMessage,
+          duration: HomeRootBack.window,
+          bottomClearance: showNavBar
+              ? kBottomNavigationBarHeight + S1FabLayout.snackBarGap
+              : null,
+        );
+      case HomeRootBackAction.exit:
+        _exitArmedAt = null;
+        SystemNavigator.pop();
+      case HomeRootBackAction.ignore:
+        break;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -122,126 +169,140 @@ class _HomeScreenBodyState extends ConsumerState<_HomeScreenBody> {
     final unreadDisplay = isLoggedIn
         ? ref.watch(unreadCountProvider.select((c) => c.displayBadge))
         : '';
+    final showNavBar = router == null || !context.isMediumOrAbove;
 
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 0,
-        title: Text(
-          isProfileTab
-              ? '个人资料'
-              : isMessagesTab
-                  ? '消息'
-                  : 'Stage1st',
-        ),
-        actions: isProfileTab
-            ? [
-                if (isLoggedIn)
-                  AppBarMoreMenu(
-                    onRefresh: () =>
-                        ref.read(authStateProvider.notifier).refreshProfile(),
-                    browserUrl: '${ApiConfig.baseUrl}/home.php?mod=space',
-                  ),
-              ]
-            : isMessagesTab
-                ? [
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        _handleHomeRootPop(
+          didPop: didPop,
+          isForumTab: selectedTab == 0,
+          isMessagesTab: isMessagesTab,
+          router: router,
+          showNavBar: showNavBar,
+        );
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          elevation: 0,
+          title: Text(
+            isProfileTab
+                ? '个人资料'
+                : isMessagesTab
+                    ? '消息'
+                    : 'Stage1st',
+          ),
+          actions: isProfileTab
+              ? [
+                  if (isLoggedIn)
                     AppBarMoreMenu(
-                      onRefresh: () {
-                        ref.read(pmListProvider.notifier).refresh();
-                        ref.read(noticeListProvider.notifier).refresh();
-                      },
-                      browserUrl: messagesBrowserUrl(
-                        messagesSegment,
-                        noticeFeed: noticeFeed,
-                        page: messagesPage,
-                      ),
+                      onRefresh: () =>
+                          ref.read(authStateProvider.notifier).refreshProfile(),
+                      browserUrl: '${ApiConfig.baseUrl}/home.php?mod=space',
                     ),
-                  ]
-                : [
-                    if (isLoggedIn)
+                ]
+              : isMessagesTab
+                  ? [
                       AppBarMoreMenu(
-                        onRefresh: () =>
-                            ref.read(forumListProvider.notifier).refresh(),
-                        browserUrl: ApiConfig.baseUrl,
-                      )
-                    else
-                      Padding(
-                        padding: const EdgeInsets.only(right: 16),
-                        child: FilledButton.tonal(
-                          onPressed: () => context.push('/login'),
-                          child: const Text('登录'),
+                        onRefresh: () {
+                          ref.read(pmListProvider.notifier).refresh();
+                          ref.read(noticeListProvider.notifier).refresh();
+                        },
+                        browserUrl: messagesBrowserUrl(
+                          messagesSegment,
+                          noticeFeed: noticeFeed,
+                          page: messagesPage,
                         ),
                       ),
-                  ],
-      ),
-      body: S1ContentWidth(
-        child: isLoggedIn
-            ? selectedTab == 0
-                ? const _ForumTab()
-                : selectedTab == 1
-                    ? const SearchScreen()
-                    : selectedTab == 2
-                        ? const MessagesScreen()
-                        : const ProfileBody(
-                            key: ValueKey('profile-logged-in'),
-                          )
-            : selectedTab == 0
-                ? const _ForumTab()
-                : const ProfileBody(key: ValueKey('profile-guest')),
-      ),
-      bottomNavigationBar: router != null && context.isMediumOrAbove
-          ? null
-          : S1HomeNavChrome(
-              child: NavigationBar(
-                selectedIndex: selectedTab,
-                onDestinationSelected: (index) {
-                  S1Haptics.selection();
-                  if (selectedTab == 2 && index != 2) {
-                    ref.read(messagesSegmentProvider.notifier).select(0);
-                  }
-                  if (router == null) {
-                    setState(() => _fallbackTab = index);
-                    return;
-                  }
-                  final tab = isLoggedIn
-                      ? const ['forum', 'search', 'messages', 'profile'][index]
-                      : const ['forum', 'profile'][index];
-                  context.go(tab == 'forum' ? '/' : '/?tab=$tab');
-                },
-                destinations: isLoggedIn
-                    ? [
-                        const NavigationDestination(
-                          icon: Icon(Icons.forum),
-                          label: '论坛',
-                        ),
-                        const NavigationDestination(
-                          icon: Icon(Icons.search),
-                          label: '搜索',
-                        ),
-                        NavigationDestination(
-                          icon: Badge(
-                            label: Text(unreadDisplay),
-                            isLabelVisible: unreadTotal > 0,
-                            child: const Icon(Icons.message),
+                    ]
+                  : [
+                      if (isLoggedIn)
+                        AppBarMoreMenu(
+                          onRefresh: () =>
+                              ref.read(forumListProvider.notifier).refresh(),
+                          browserUrl: ApiConfig.baseUrl,
+                        )
+                      else
+                        Padding(
+                          padding: const EdgeInsets.only(right: 16),
+                          child: FilledButton.tonal(
+                            onPressed: () => context.push('/login'),
+                            child: const Text('登录'),
                           ),
-                          label: '消息',
                         ),
-                        const NavigationDestination(
-                          icon: Icon(Icons.person),
-                          label: '我的',
-                        ),
-                      ]
-                    : const [
-                        NavigationDestination(
-                          icon: Icon(Icons.forum),
-                          label: '论坛',
-                        ),
-                        NavigationDestination(
-                          icon: Icon(Icons.person),
-                          label: '我的',
-                        ),
-                      ],
+                    ],
+        ),
+        body: S1ContentWidth(
+          child: isLoggedIn
+              ? selectedTab == 0
+                  ? const _ForumTab()
+                  : selectedTab == 1
+                      ? const SearchScreen()
+                      : selectedTab == 2
+                          ? const MessagesScreen()
+                          : const ProfileBody(
+                              key: ValueKey('profile-logged-in'),
+                            )
+              : selectedTab == 0
+                  ? const _ForumTab()
+                  : const ProfileBody(key: ValueKey('profile-guest')),
+        ),
+        bottomNavigationBar: router != null && context.isMediumOrAbove
+            ? null
+            : S1HomeNavChrome(
+                child: NavigationBar(
+                  selectedIndex: selectedTab,
+                  onDestinationSelected: (index) {
+                    S1Haptics.selection();
+                    if (selectedTab == 2 && index != 2) {
+                      ref.read(messagesSegmentProvider.notifier).select(0);
+                    }
+                    if (router == null) {
+                      setState(() => _fallbackTab = index);
+                      return;
+                    }
+                    final tabs = isLoggedIn
+                        ? const ['forum', 'search', 'messages', 'profile']
+                        : const ['forum', 'profile'];
+                    final tab = tabs[index];
+                    context.go(tab == 'forum' ? '/' : '/?tab=$tab');
+                  },
+                  destinations: isLoggedIn
+                      ? [
+                          const NavigationDestination(
+                            icon: Icon(Icons.forum),
+                            label: '论坛',
+                          ),
+                          const NavigationDestination(
+                            icon: Icon(Icons.search),
+                            label: '搜索',
+                          ),
+                          NavigationDestination(
+                            icon: Badge(
+                              label: Text(unreadDisplay),
+                              isLabelVisible: unreadTotal > 0,
+                              child: const Icon(Icons.message),
+                            ),
+                            label: '消息',
+                          ),
+                          const NavigationDestination(
+                            icon: Icon(Icons.person),
+                            label: '我的',
+                          ),
+                        ]
+                      : const [
+                          NavigationDestination(
+                            icon: Icon(Icons.forum),
+                            label: '论坛',
+                          ),
+                          NavigationDestination(
+                            icon: Icon(Icons.person),
+                            label: '我的',
+                          ),
+                        ],
+                ),
               ),
-            ),
+      ),
     );
   }
 }

--- a/lib/utils/home_root_back.dart
+++ b/lib/utils/home_root_back.dart
@@ -1,0 +1,36 @@
+/// 首页根路由上的系统返回：先回论坛 Tab，论坛上再确认才退出。
+enum HomeRootBackAction {
+  /// 当前不是论坛 Tab，切回论坛。
+  goForum,
+
+  /// 已在论坛：提示「再返回一次」并开始退出窗口。
+  armExit,
+
+  /// 退出窗口内再次返回，可以退出应用。
+  exit,
+
+  /// 已在论坛但不在可退出平台（非 Android），吞掉返回。
+  ignore,
+}
+
+/// 首页根返回的时间窗口与提示文案。
+abstract class HomeRootBack {
+  static const window = Duration(seconds: 2);
+  static const snackMessage = '再返回一次退出应用';
+}
+
+/// 判定首页根（无子路由可 pop）时系统返回该做什么。
+HomeRootBackAction resolveHomeRootBack({
+  required bool isForumTab,
+  required DateTime now,
+  DateTime? lastExitArmedAt,
+  required bool canExitApp,
+  Duration window = HomeRootBack.window,
+}) {
+  if (!isForumTab) return HomeRootBackAction.goForum;
+  if (!canExitApp) return HomeRootBackAction.ignore;
+  if (lastExitArmedAt != null && now.difference(lastExitArmedAt) <= window) {
+    return HomeRootBackAction.exit;
+  }
+  return HomeRootBackAction.armExit;
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -11,6 +12,7 @@ import 'package:s1er/providers/messages_segment_provider.dart';
 import 'package:s1er/providers/settings_provider.dart';
 import 'package:s1er/screens/home_screen.dart';
 import 'package:s1er/theme/app_theme.dart';
+import 'package:s1er/utils/home_root_back.dart';
 import 'package:drift/native.dart';
 import 'package:s1er/services/app_database.dart';
 import 'package:s1er/services/app_local_data.dart';
@@ -199,6 +201,83 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('我对 Kiyohara_Yasuke 说'), findsOneWidget);
     expect(messagesBrowserUrl(1), contains('do=pm'));
+  });
+
+  testWidgets('system back from search returns to forum tab', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedInAuthNotifier.new),
+          forumListProvider.overrideWith(_GuestForumListNotifier.new),
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(initial: const AppSettings()),
+          ),
+          ...messagesProviderOverrides(),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple'),
+          home: const HomeScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('搜索'));
+    await tester.pumpAndSettle();
+    expect(find.text('搜索主题与帖子'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('搜索主题与帖子'), findsNothing);
+    expect(find.text('主论坛'), findsOneWidget);
+    expect(find.text(HomeRootBack.snackMessage), findsNothing);
+  });
+
+  testWidgets('forum tab first back shows exit hint without leaving',
+      (tester) async {
+    final platformCalls = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        platformCalls.add(call.method);
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authStateProvider.overrideWith(_LoggedInAuthNotifier.new),
+          forumListProvider.overrideWith(_GuestForumListNotifier.new),
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(initial: const AppSettings()),
+          ),
+          ...messagesProviderOverrides(),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.lightTheme('purple').copyWith(
+            platform: TargetPlatform.android,
+          ),
+          home: const HomeScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('主论坛'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(find.text(HomeRootBack.snackMessage), findsOneWidget);
+    expect(find.text('主论坛'), findsOneWidget);
+    expect(platformCalls, isNot(contains('SystemNavigator.pop')));
   });
 
   testWidgets('guest profile tab then login resets to forum tab without error',

--- a/test/utils/home_root_back_test.dart
+++ b/test/utils/home_root_back_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s1er/utils/home_root_back.dart';
+
+void main() {
+  final now = DateTime(2026, 8, 18, 10);
+
+  test('non-forum tab goes back to forum', () {
+    expect(
+      resolveHomeRootBack(
+        isForumTab: false,
+        now: now,
+        lastExitArmedAt: now,
+        canExitApp: true,
+      ),
+      HomeRootBackAction.goForum,
+    );
+    expect(
+      resolveHomeRootBack(
+        isForumTab: false,
+        now: now,
+        canExitApp: false,
+      ),
+      HomeRootBackAction.goForum,
+    );
+  });
+
+  test('forum tab first back arms exit', () {
+    expect(
+      resolveHomeRootBack(
+        isForumTab: true,
+        now: now,
+        canExitApp: true,
+      ),
+      HomeRootBackAction.armExit,
+    );
+  });
+
+  test('forum tab back within window exits', () {
+    expect(
+      resolveHomeRootBack(
+        isForumTab: true,
+        now: now.add(HomeRootBack.window),
+        lastExitArmedAt: now,
+        canExitApp: true,
+      ),
+      HomeRootBackAction.exit,
+    );
+  });
+
+  test('forum tab back after window arms again', () {
+    expect(
+      resolveHomeRootBack(
+        isForumTab: true,
+        now: now.add(HomeRootBack.window + const Duration(milliseconds: 1)),
+        lastExitArmedAt: now,
+        canExitApp: true,
+      ),
+      HomeRootBackAction.armExit,
+    );
+  });
+
+  test('forum tab does not exit off Android', () {
+    expect(
+      resolveHomeRootBack(
+        isForumTab: true,
+        now: now,
+        lastExitArmedAt: now,
+        canExitApp: false,
+      ),
+      HomeRootBackAction.ignore,
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
从搜索 / 消息 / 个人按系统返回时，先回到论坛 Tab，而不是直接退出到桌面。已在论坛时，第一次返回弹出 SnackBar「再返回一次退出应用」（2 秒窗口）；窗口内再返回一次才在 Android 上 `SystemNavigator.pop()`。

文案用「返回」而不是「按」，同时覆盖三键返回和全面屏侧滑。iOS / 桌面 / Web 不调用退出。子路由（帖子、设置等）不拦截。

## 测试

- `home_root_back` 单元：非论坛 → 回论坛；首次武装；窗口内退出；超时再武装；非 Android 忽略
- `home_screen_test`：搜索返回论坛；论坛 Tab 第一次返回出现提示且不退出

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

