### PR TITLE
fix(ui): shrink standard post avatar to match author type

### DIFF
--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -53,7 +53,7 @@ class PostItemDensityTokens {
   final bool inlineAuthorMeta;
   final double narrowColumnGap;
 
-  /// Header 右侧菜单按钮最小宽高（对齐头像视觉高度）。
+  /// Header 右侧菜单按钮最小宽高（对齐头像直径）。
   final double headerActionExtent;
   final double headerActionIconSize;
   final EdgeInsetsGeometry floorBadgePadding;
@@ -62,12 +62,12 @@ class PostItemDensityTokens {
     cardMarginVertical: 4,
     cardPadding: 12,
     cardPaddingTop: 12,
-    avatarRadius: 20,
+    avatarRadius: 16,
     dividerHeight: 16,
     inlineAuthorMeta: false,
     narrowColumnGap: 8,
-    headerActionExtent: 40,
-    headerActionIconSize: 24,
+    headerActionExtent: 32,
+    headerActionIconSize: 20,
     floorBadgePadding: EdgeInsets.symmetric(horizontal: 6, vertical: 2),
   );
 

--- a/lib/widgets/skeleton/post_item_skeleton.dart
+++ b/lib/widgets/skeleton/post_item_skeleton.dart
@@ -23,7 +23,7 @@ class PostItemSkeleton extends ConsumerWidget {
         children: [
           Row(
             children: [
-              S1SkeletonCircle(size: 40),
+              S1SkeletonCircle(size: 32),
               SizedBox(width: 12),
               Expanded(
                 child: Column(

--- a/test/widgets/post_item_density_test.dart
+++ b/test/widgets/post_item_density_test.dart
@@ -47,19 +47,24 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('standard post density uses larger avatar chrome',
+  testWidgets('standard post density matches 32dp avatar chrome',
       (tester) async {
     await pumpPost(tester, density: ListDensity.standard);
     final avatar = tester.widget<WebAvatar>(find.byType(WebAvatar));
     final card = tester.widget<Card>(find.byType(Card).first);
-    expect(avatar.radius, 20);
+    expect(avatar.radius, 16);
     expect(
       card.margin,
       const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
     );
+    final menuButton = tester.widget<IconButton>(find.byType(IconButton));
+    expect(
+      menuButton.style?.minimumSize?.resolve(const <WidgetState>{}),
+      const Size(32, 32),
+    );
   });
 
-  testWidgets('compact post density uses smaller avatar chrome',
+  testWidgets('compact post density uses tighter padding than standard',
       (tester) async {
     await pumpPost(tester, density: ListDensity.compact);
     final avatar = tester.widget<WebAvatar>(find.byType(WebAvatar));
@@ -80,7 +85,11 @@ void main() {
   test('PostItemDensityTokens map density modes', () {
     expect(
       PostItemDensityTokens.forDensity(ListDensity.standard).avatarRadius,
-      20,
+      16,
+    );
+    expect(
+      PostItemDensityTokens.forDensity(ListDensity.standard).headerActionExtent,
+      32,
     );
     expect(
       PostItemDensityTokens.forDensity(ListDensity.compact).inlineAuthorMeta,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
标准密度楼层头像从 40dp 收到 **32dp**（`avatarRadius: 16`），和已经缩小的两行用户名对齐。菜单热区同样 32dp，骨架圆点跟上。

紧凑档本来就是 32dp，不再往小收。不加新设置。密度差异继续靠间距和「两行 / 一行」元信息。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9c98be-aac1-450d-b0b4-16a5ab3ac3a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

